### PR TITLE
Print HTTP responses to cf log debug info

### DIFF
--- a/lib/common/index.js
+++ b/lib/common/index.js
@@ -65,3 +65,33 @@ module.exports.API_VERSION = {
     SQL: '2014-04-01-preview'
   }
 };
+
+module.exports.logHttpResponse = function (log, res, operation, logBody) {
+  if (!(log && res)) return;
+  if (typeof log.debug !== 'function') return;
+
+  var message = '';
+  
+  if (typeof operation === 'string') {
+    message += util.format('receive from: %s\n', operation);
+  }
+  
+  if (res.headers) {
+    var keys = ['x-ms-request-id', 'x-ms-correlation-request-id', 'x-ms-routing-request-id'];
+    var keysLen = keys.length;
+    for (var i = 0; i < keysLen; i++) {
+      if (res.headers[keys[i]]) {
+        message += util.format('%s: %s\n', keys[i], res.headers[keys[i]]);
+      }
+    }
+  }
+  if (logBody) {
+    if (res.body) {
+      message += util.format('%s: %s\n', 'body', res.body);
+    }
+  } else {
+    message += 'response.body cannot be logged because it may contain credentials.\n';
+  }
+  
+  log.debug('HTTP Response: %s', message);
+};

--- a/lib/common/resourceGroup-client.js
+++ b/lib/common/resourceGroup-client.js
@@ -7,8 +7,12 @@ var common = require('./index');
 
 var resourceGroup;
 
-exports.instantiate = function(azure) {
+var log;
 
+exports.instantiate = function(azure, logger) {
+    
+    log = logger;
+    
     var environment = common.getEnvironment(azure.environment);
     var options = {
         environment: environment
@@ -23,12 +27,14 @@ exports.instantiate = function(azure) {
 
 exports.createOrUpdate = function(resourceGroupName, groupParameters, next) {
     resourceGroup.createOrUpdate(resourceGroupName, groupParameters, function (err, result, request, response) {
+        common.logHttpResponse(log, response, 'Create or update resource group', true);
         next(err, result);
     });
 };
 
 exports.checkExistence = function(resourceGroupName, next) {
     resourceGroup.checkExistence(resourceGroupName, function (err, result, request, response) {
+        common.logHttpResponse(log, response, 'Check resource group existence', true);
         next(err, result);
     });
 };

--- a/lib/services/azuredocdb/client.js
+++ b/lib/services/azuredocdb/client.js
@@ -7,13 +7,19 @@ var docDb;
 var hostEndPoint = process.env['docDb_hostEndPoint'];
 var masterKey = process.env['docDb_masterKey'];
 
-exports.instantiate = function() {
+var common = require('../../common/');
+
+var log;
+
+exports.instantiate = function(logger) {
+    log = logger;
     docDb = new docDbClient(hostEndPoint, {masterKey:masterKey});
     // console.log('docDb-client instantiate: docDb object: %j', docDb);
 };
 
 exports.provision = function(databaseName, next) {
-    docDb.createDatabase({id:databaseName}, function(err, database) {
+    docDb.createDatabase({id:databaseName}, function(err, database, responseHeaders) {
+        common.logHttpResponse(log, {'headers': responseHeaders}, 'Create docDB', true);
         next(err, database);
     });
 };
@@ -30,7 +36,8 @@ exports.poll = function(databaseName, next) {
         ]
     };
     
-    docDb.queryDatabases(querySpec).toArray(function(err, results) {
+    docDb.queryDatabases(querySpec).toArray(function(err, results, responseHeaders) {
+        common.logHttpResponse(log, {'headers': responseHeaders}, 'Query docDB', true);
         if (err) return next(err, null);
         if (results.length === 0) {
             next(null, null);
@@ -41,7 +48,8 @@ exports.poll = function(databaseName, next) {
 };
 
 exports.deprovision = function(databaseLink, next) {
-    docDb.deleteDatabase(databaseLink, function(err, result) {
+    docDb.deleteDatabase(databaseLink, function(err, result, responseHeaders) {
+        common.logHttpResponse(log, {'headers': responseHeaders}, 'Delete DocDB', true);
         next(err, result);
     });
 };

--- a/lib/services/azuredocdb/index.js
+++ b/lib/services/azuredocdb/index.js
@@ -36,8 +36,8 @@ Handlers.provision = function(log, params, next) {
     return;
   }
 
-  resourceGroupClient.instantiate(params.azure);
-  docDbClient.instantiate();
+  resourceGroupClient.instantiate(params.azure, log);
+  docDbClient.instantiate(log);
   cp.provision(docDbClient, resourceGroupClient, function(err, result) {
     if (err) {
       var statusCode = null;
@@ -67,7 +67,7 @@ Handlers.poll = function(log, params, next) {
     return;
   }
 
-  docDbClient.instantiate();
+  docDbClient.instantiate(log);
   cp.poll(docDbClient, function(err, result) {
     if (err) {
       var statusCode = null;
@@ -97,7 +97,7 @@ Handlers.deprovision = function(log, params, next) {
     return;
   }
 
-  docDbClient.instantiate(params.azure);
+  docDbClient.instantiate(params.azure, log);
   cp.deprovision(docDbClient, function(err, result) {
     if (err) {
       var statusCode = null;

--- a/lib/services/azurerediscache/client.js
+++ b/lib/services/azurerediscache/client.js
@@ -8,8 +8,12 @@ var common = require('../../common/');
 
 var redis;
 
-exports.instantiate = function(azure) {
+var log;
 
+exports.instantiate = function(azure, logger) {
+
+    var log = logger;
+    
     var environment = common.getEnvironment(azure.environment);
     var options = {
         environment: environment
@@ -23,19 +27,22 @@ exports.instantiate = function(azure) {
 };
 
 exports.provision = function(resourceGroup, cacheName, parameters, next) {
-    redis.createOrUpdate(resourceGroup, cacheName, parameters, function(err, result) {
+    redis.createOrUpdate(resourceGroup, cacheName, parameters, function(err, result, request, response) {
+        common.logHttpResponse(log, response, 'Create or update Redis Cache', true);
         next(err, result);
     });
 };
 
 exports.poll = function(resourceGroup, cacheName, next) {
-    redis.get(resourceGroup, cacheName, function(err, result) {
+    redis.get(resourceGroup, cacheName, function(err, result, request, response) {
+        common.logHttpResponse(log, response, 'Get Redis Cache', true);
         next(err, result);
     });
 };
 
 exports.deprovision = function(resourceGroup, cacheName, next) {
-    redis.deleteMethod(resourceGroup, cacheName, function(err, result) {
+    redis.deleteMethod(resourceGroup, cacheName, function(err, result, request, response) {
+        common.logHttpResponse(log, response, 'Delete Redis Cache', true);
         next(err, result);
     });
 };

--- a/lib/services/azurerediscache/index.js
+++ b/lib/services/azurerediscache/index.js
@@ -34,8 +34,8 @@ Handlers.provision = function (log, params, next) {
     return;
   }
 
-  resourceGroupClient.instantiate(params.azure);
-  redisClient.instantiate(params.azure);
+  resourceGroupClient.instantiate(params.azure, log);
+  redisClient.instantiate(params.azure, log);
   cp.provision(redisClient, resourceGroupClient, function (err, result) {
     if (err) {
       var statusCode = null;
@@ -65,7 +65,7 @@ Handlers.poll = function (log, params, next) {
     return;
   }
 
-  redisClient.instantiate(params.azure);
+  redisClient.instantiate(params.azure, log);
   cp.poll(redisClient, function (err, result) {
 
     if (err) {
@@ -96,7 +96,7 @@ Handlers.deprovision = function (log, params, next) {
     return;
   }
 
-  redisClient.instantiate(params.azure);
+  redisClient.instantiate(params.azure, log);
   cp.deprovision(redisClient, function (err, result) {
 
     if (err) {

--- a/lib/services/azureservicebus/index.js
+++ b/lib/services/azureservicebus/index.js
@@ -60,7 +60,7 @@ Handlers.provision = function(log, params, next) {
     sbType : reqParams[reqParamsKey[3]],
     sbTier : reqParams[reqParamsKey[4]]
   };
-  utils.init(params.azure, config);
+  utils.init(params.azure, config, log);
 
   async.waterfall([
       utils.getToken,
@@ -101,7 +101,7 @@ Handlers.poll = function(log, params, next) {
     resourceGroupName : resourceGroupName,
     namespaceName : namespaceName,
   };
-  utils.init(params.azure, config);
+  utils.init(params.azure, config, log);
 
   async.waterfall([
       utils.getToken,
@@ -173,7 +173,7 @@ Handlers.deprovision = function(log, params, next) {
     resourceGroupName : resourceGroupName,
     namespaceName : namespaceName,
   };
-  utils.init(params.azure, config);
+  utils.init(params.azure, config, log);
 
   async.waterfall([
       utils.getToken,
@@ -205,7 +205,7 @@ Handlers.bind = function(log, params, next) {
     resourceGroupName : resourceGroupName,
     namespaceName : namespaceName,
   };
-  utils.init(params.azure, config);
+  utils.init(params.azure, config, log);
 
   async.waterfall([
       utils.getToken,

--- a/lib/services/azureservicebus/utils.js
+++ b/lib/services/azureservicebus/utils.js
@@ -10,6 +10,7 @@ var API_VERSIONS;
 var environment;
 var azure_properties;
 var azure_config;
+var log;
 
 String.prototype.format = function() {
     var formatted = this;
@@ -19,7 +20,8 @@ String.prototype.format = function() {
     return formatted;
 };
 
-exports.init = function(properties, config) {
+exports.init = function(properties, config, logger) {
+  log = logger;
   azure_properties = properties;
   azure_config = config;
 
@@ -45,6 +47,7 @@ exports.getToken = function(callback) {
         'scope': 'user_impersonation'
     }
   }, function(err, response, body){
+    common.logHttpResponse(log, response, 'Get authorization token', false);
     if(err) {
         callback(err);
     } else {
@@ -73,6 +76,7 @@ exports.createResourceGroup = function(accessToken, callback){
         'location': azure_config.location
     }
 }, function(err, response, body){
+     common.logHttpResponse(log, response, 'Create or update resource group', true);
      if(err) {
          callback(err);
      } else {
@@ -107,6 +111,7 @@ exports.createNamespace = function(accessToken, callback) {
         }
     }
   }, function(err, response, body){
+       common.logHttpResponse(log, response, 'Create namespace', true);
        if(err) {
            callback(err);
        } else {
@@ -132,6 +137,7 @@ exports.getNamespace = function(accessToken, callback) {
         'Authorization': 'Bearer ' + accessToken
     }
   }, function(err, response, body){
+       common.logHttpResponse(log, response, 'Get namespace', true);
        if(err) {
            callback(err);
        } else {
@@ -158,6 +164,7 @@ exports.listNamespaceKeys = function(accessToken, callback) {
         'Authorization': 'Bearer ' + accessToken
     }
   }, function(err, response, body){
+       common.logHttpResponse(log, response, 'List namespace keys', false);
        if(err) {
            callback(err);
        } else {
@@ -184,6 +191,7 @@ exports.delNamespace = function(accessToken, callback) {
         'Authorization': 'Bearer ' + accessToken
     }
   }, function(err, response, body){
+       common.logHttpResponse(log, response, 'Delete namespace', true);
        if(err) {
            callback(err);
        } else {

--- a/lib/services/azuresqldb/client.js
+++ b/lib/services/azuresqldb/client.js
@@ -120,6 +120,9 @@ sqldbOperations.prototype.getToken = function (callback) {
         scope: 'user_impersonation'
     };
     that.POST(url, headers, data, API_VERSIONS.TOKEN, true, function (err, response, body) {
+        
+        common.logHttpResponse(that.log, response, 'Get authorization token', false);
+        
         that.log.info('sqldb client: getToken: POST invocation');
         if (err) {
             callback(err);
@@ -166,7 +169,9 @@ sqldbOperations.prototype.createFirewallRule = function (startIpAddress, endIpAd
     data.properties.endIpAddress = endIpAddress;
 
     that.PUT(that.firewallRuleUrl, that.standardHeaders, data, API_VERSIONS.SQL, function (err, res, body) {
-
+        
+        common.logHttpResponse(that.log, res, 'Create SQL server firewall rules', true);
+    
         that.log.info('sqldb client: createFirewallRule');
 
         var result = {};
@@ -192,6 +197,8 @@ sqldbOperations.prototype.getServer = function (parameters, callback) {
 
     that.GET(that.serverUrl, that.standardHeaders, API_VERSIONS.SQL, function (err, res, body) {
 
+        common.logHttpResponse(that.log, res, 'Get SQL server', true);
+        
         that.log.info('sqldb client: getServer');
 
         var result = {};
@@ -223,6 +230,8 @@ sqldbOperations.prototype.createServer = function (parameters, callback) {
     
     that.PUT(that.serverUrl, that.standardHeaders, sqlServerParameters, API_VERSIONS.SQL, function (err, res, body) {
 
+        common.logHttpResponse(that.log, res, 'Create SQL server', true);
+        
         that.log.info('sqldb client: createServer');
 
         var result = {};
@@ -252,6 +261,8 @@ sqldbOperations.prototype.getDatabase = function (callback) {
 
     that.GET(that.sqldbUrl, that.standardHeaders, API_VERSIONS.SQL, function (err, res, body) {
 
+        common.logHttpResponse(that.log, res, 'Get SQL database', true);
+        
         that.log.info('sqldb client: getDatabase');
 
         var result = {};
@@ -278,6 +289,8 @@ sqldbOperations.prototype.createDatabase = function (parameters, callback) {
 
     that.PUT(that.sqldbUrl, that.standardHeaders, parameters.sqldbParameters, API_VERSIONS.SQL, function (err, res, body) {
 
+        common.logHttpResponse(that.log, res, 'Create SQL database', true);
+        
         that.log.info('sqldb client: createDatabase: parameters: %j', parameters.sqldbParameters);
 
         var result = {};
@@ -302,6 +315,8 @@ sqldbOperations.prototype.deleteDatabase = function (callback) {
     var that = this;
 
     that.DELETE(that.sqldbUrl, that.standardHeaders, API_VERSIONS.SQL, function (err, res) {
+        
+        common.logHttpResponse(that.log, res, 'Delete SQL database', true);
 
         that.log.info('sqldb client: deleteDatabase');
 

--- a/lib/services/azuresqldb/index.js
+++ b/lib/services/azuresqldb/index.js
@@ -39,7 +39,7 @@ Handlers.provision = function (log, params, next) {
     return;
   }
 
-  resourceGroupClient.instantiate(params.azure);
+  resourceGroupClient.instantiate(params.azure, log);
   log.info('sqldb index: resourceGroupClient is instantiated');
 
   var sqldbOps = new sqldbOperations(log, params.azure);

--- a/lib/services/azurestorageblob/index.js
+++ b/lib/services/azurestorageblob/index.js
@@ -63,7 +63,7 @@ Handlers.provision = function(log, params, next) {
     accountType: reqParams[reqParamsKey[4]],
   };
 
-  storageBlobClient.init(params.azure);
+  storageBlobClient.init(params.azure, log);
 
   storageBlobClient.provision(resourceGroupName, groupParameters,
     storageAccountName, accountParameters,
@@ -97,7 +97,7 @@ Handlers.poll = function(log, params, next) {
   var resourceGroupName = provisioningResult.resourceGroupResult.resourceGroupName;
   var storageAccountName = provisioningResult.storageAccountResult.storageAccountName;
 
-  storageBlobClient.init(params.azure);
+  storageBlobClient.init(params.azure, log);
 
   storageBlobClient.poll(resourceGroupName, storageAccountName, function(err, state) {
     var reply = {
@@ -154,7 +154,7 @@ Handlers.deprovision = function(log, params, next) {
   var resourceGroupName = provisioningResult.resourceGroupResult.resourceGroupName;
   var storageAccountName = provisioningResult.storageAccountResult.storageAccountName;
 
-  storageBlobClient.init(params.azure);
+  storageBlobClient.init(params.azure, log);
 
   storageBlobClient.deprovision(resourceGroupName, storageAccountName, function(err) {
     if (err) {
@@ -184,7 +184,7 @@ Handlers.bind = function(log, params, next) {
   var resourceGroupName = provisioningResult.resourceGroupResult.resourceGroupName;
   var storageAccountName = provisioningResult.storageAccountResult.storageAccountName;
 
-  storageBlobClient.init(params.azure);
+  storageBlobClient.init(params.azure, log);
 
   storageBlobClient.bind(resourceGroupName, storageAccountName, containerName,
     function(err, primaryAccessKey, secondaryAccessKey) {
@@ -221,7 +221,7 @@ Handlers.unbind = function(log, params, next) {
   var resourceGroupName = provisioningResult.resourceGroupResult.resourceGroupName;
   var storageAccountName = provisioningResult.storageAccountResult.storageAccountName;
 
-  storageBlobClient.init(params.azure);
+  storageBlobClient.init(params.azure, log);
 
   storageBlobClient.unbind(resourceGroupName, storageAccountName, function(err) {
     if (err) {

--- a/lib/services/azurestorageblob/storageblobclient.js
+++ b/lib/services/azurestorageblob/storageblobclient.js
@@ -14,9 +14,11 @@ var common = require('../../common');
 var resourceClient;
 var storageClient;
 var options = {};
+var log;
 
-exports.init = function(azure) {
-
+exports.init = function(azure, logger) {
+  log = logger;
+  
   options.environment = common.getEnvironment(azure.environment);
 
   var credentials = new msRestAzure.ApplicationTokenCredentials(azure.client_id, azure.tenant_id, azure.client_secret, options);
@@ -31,6 +33,7 @@ exports.provision = function(resourceGroupName, groupParameters, storageAccountN
       function(callback) {
         resourceClient.resourceGroups.createOrUpdate(resourceGroupName, groupParameters,
           function(err, result, request, response) {
+            common.logHttpResponse(log, response, 'Create or update resource group', true);
             callback(err, {
               resourceGroupName: resourceGroupName,
               groupParameters: groupParameters,
@@ -40,6 +43,7 @@ exports.provision = function(resourceGroupName, groupParameters, storageAccountN
       function(callback) {
         storageClient.storageAccounts.beginCreate(resourceGroupName, storageAccountName, accountParameters,
           function(err, result, request, response) {
+            common.logHttpResponse(log, response, 'Create storage account', true);
             callback(err, {
               storageAccountName: storageAccountName,
               accountParameters: accountParameters,
@@ -55,6 +59,7 @@ exports.provision = function(resourceGroupName, groupParameters, storageAccountN
 exports.poll = function(resourceGroupName, storageAccountName, next) {
   storageClient.storageAccounts.getProperties(resourceGroupName, storageAccountName,
     function(err, result, request, response) {
+      common.logHttpResponse(log, response, 'Get storage account properties', true);
       if (err) {
         next(err);
       } else {
@@ -66,6 +71,7 @@ exports.poll = function(resourceGroupName, storageAccountName, next) {
 exports.deprovision = function(resourceGroupName, storageAccountName, next) {
   storageClient.storageAccounts.deleteMethod(resourceGroupName, storageAccountName,
     function(err, result, request, response) {
+      common.logHttpResponse(log, response, 'Delete storage account', true);
       next(err);
     });
 };
@@ -75,6 +81,7 @@ exports.bind = function(resourceGroupName, storageAccountName, containerName, ne
       function(callback) {
         storageClient.storageAccounts.listKeys(resourceGroupName, storageAccountName,
           function(err, result, response) {
+            common.logHttpResponse(log, response, 'List storage keys', false);
             if (err) {
               callback(err);
             } else {
@@ -91,6 +98,7 @@ exports.bind = function(resourceGroupName, storageAccountName, containerName, ne
             publicAccessLevel: 'blob'
           },
           function(err, result, response) {
+            common.logHttpResponse(log, response, 'Create storage container', true);
             if (err) {
               callback(err);
             } else {
@@ -109,12 +117,14 @@ exports.unbind = function(resourceGroupName, storageAccountName, next) {
       function(callback) {
         storageClient.storageAccounts.regenerateKey(resourceGroupName, storageAccountName, 'key1', {},
           function(err, result, response) {
+            common.logHttpResponse(log, response, 'Regenerate storage account key1', false);
             callback(err);
           });
       },
       function(callback) {
         storageClient.storageAccounts.regenerateKey(resourceGroupName, storageAccountName, 'key2', {},
           function(err, result, response) {
+            common.logHttpResponse(log, response, 'Regenerate storage account key2', false);
             callback(err);
           });
       }

--- a/test/unit/common/utils-tests.js
+++ b/test/unit/common/utils-tests.js
@@ -1,7 +1,11 @@
+var logule = require('logule');
 var should = require('should');
+var sinon = require('sinon');
+var util = require('util');
 var AzureEnvironment = require('ms-rest-azure').AzureEnvironment;
 
 var Common = require('../../../lib/common');
+var log = logule.init(module, 'ServiceBroker-Mocha');
 
 describe('Util', function() {
 
@@ -16,4 +20,59 @@ describe('Util', function() {
     });
   });
 
+  describe('logHttpResponse()', function() {
+    before(function() {
+      sinon.stub(log, 'debug');
+    });
+
+    after(function() {
+      log.debug.restore();
+    });
+
+    it('should call log.debug with correct message when logging body', function() {
+      var operation = 'operationx';
+      Common.logHttpResponse(log,
+                             {
+                               headers: {
+                                 'x-ms-request-id': 'aaa',
+                                 'x-ms-correlation-request-id': 'bbb',
+                                 'x-ms-routing-request-id': 'ccc'
+                               },
+                               'body': 'ddd'
+                             },
+                             operation,
+                             true);
+
+      var message = util.format('receive from: %s\n%s: %s\n%s: %s\n%s: %s\n%s: %s\n',
+                                operation,
+                                'x-ms-request-id', 'aaa',
+                                'x-ms-correlation-request-id', 'bbb',
+                                'x-ms-routing-request-id', 'ccc',
+                                'body', 'ddd');
+      sinon.assert.calledWithMatch(log.debug, 'HTTP Response: %s', message);
+    });
+
+    it('should call log.debug with correct message when not logging body', function() {
+      var operation = 'operationx';
+      Common.logHttpResponse(log,
+                             {
+                               headers: {
+                                 'x-ms-request-id': 'aaa',
+                                 'x-ms-correlation-request-id': 'bbb',
+                                 'x-ms-routing-request-id': 'ccc'
+                               },
+                               'body': 'ddd'
+                             },
+                             operation,
+                             false);
+
+      var message = util.format('receive from: %s\n%s: %s\n%s: %s\n%s: %s\n%s\n',
+                                operation,
+                                'x-ms-request-id', 'aaa',
+                                'x-ms-correlation-request-id', 'bbb',
+                                'x-ms-routing-request-id', 'ccc',
+                                'response.body cannot be logged because it may contain credentials.');
+      sinon.assert.calledWithMatch(log.debug, 'HTTP Response: %s', message);
+    });
+  });
 });


### PR DESCRIPTION
With this change, users can see HTTP responses as debug information in return of "cf logs meta-azure-service-broker --recent".