### PR TITLE
Added jdbcUrl credential for Spring Cloud Connector support

### DIFF
--- a/lib/services/azuresqldb/index.js
+++ b/lib/services/azuresqldb/index.js
@@ -117,6 +117,11 @@ Handlers.bind = function (log, params, next) {
 
   var provisioningResult = JSON.parse(params.provisioning_result);
 
+  // Spring Cloud Connector Support
+  var jdbcUrl = 'jdbc:sqlserver://' + provisioningResult.sqlServerName + '.database.windows.net:1433;database=' +
+      provisioningResult.name + ';user=' + provisioningResult.administratorLogin + ';password=' +
+      provisioningResult.administratorLoginPassword;
+
   // contents of reply.value winds up in VCAP_SERVICES
   var reply = {
     statusCode: HttpStatus.CREATED,
@@ -126,7 +131,8 @@ Handlers.bind = function (log, params, next) {
         sqldbName: provisioningResult.name,
         sqlServerName: provisioningResult.sqlServerName,
         administratorLogin: provisioningResult.administratorLogin,
-        administratorLoginPassword: provisioningResult.administratorLoginPassword
+        administratorLoginPassword: provisioningResult.administratorLoginPassword,
+        jdbcUrl: jdbcUrl
       }
     }
   };


### PR DESCRIPTION
I propose adding jdbcUrl to the credentials environment to comply with the standard for URI-based connectors in the Spring Cloud Connectors project.

This will provide an outstanding experience for Spring Boot Developers. When pushing applications that use Spring Data support, they can simply bind to the Azure SQL service, and they will automatically connect to the database without having to parse environment variables.

I've tested the change with Spring Boot 1.4 applications.