### PR TITLE
Remove the service instance information in db if the status is not success

### DIFF
--- a/lib/broker/db/sqlserver/index.js
+++ b/lib/broker/db/sqlserver/index.js
@@ -132,7 +132,7 @@ Database.prototype.deleteServiceInstance = function(instanceId, callback) {
   sqlserver.executeSql(db.dbConfig, sql, function(err, data) {
     if (err) {
       return common.handleServiceErrorEx(db.log, HttpStatus.INTERNAL_SERVER_ERROR,
-        util.format('Failed in deleting the record for (instanceId: %s) from the broker database. DB Error: %j.', instanceId, err),
+        util.format('Failed in deleting the record for (instanceId: %s) from the broker database. You may need to delete this record manually. DB Error: %j.', instanceId, err),
         callback);
     }
 

--- a/lib/broker/v2/api-handlers.js
+++ b/lib/broker/v2/api-handlers.js
@@ -361,28 +361,6 @@ Handlers.handleDeProvisionRequest = function(broker, req, res, next) {
   var instanceId = req.params.instance_id;
   broker.log.info('handleDeProvisionRequest - (instanceId: %s) from %s:%s', instanceId, req.connection.remoteAddress, req.connection.remotePort);
 
-  var processResponse = function(error, reply, result) {
-    if (error) {
-      broker.log.error('handleDeProvisionRequest - Failed in sending deprovision request for (instanceId: %s) to Azure. Deprovision Error: %j', instanceId, error);
-      res.send(error.statusCode, error);
-
-      broker.log.info('handleDeProvisionRequest - Succeeded in sending the deprovision error response for (instanceId: %s) to cc.', instanceId);
-      return next();
-    }
-
-    broker.db.updateServiceInstanceLastOperation(instanceId, 'deprovision', function(err){
-      if (err) {
-        broker.log.error('handleDeProvisionRequest - %j', err);
-        res.send(err.statusCode, err);
-        return next();
-      }
-
-      res.send(HttpStatus.ACCEPTED, reply.value);
-      broker.log.info('handleDeProvisionRequest - Succeeded in sending the deprovision response for (instanceId: %s) to cc.', instanceId);
-      return next();
-    });
-  };
-
   broker.db.getServiceInstance(instanceId, function(err, serviceInstance) {
     if (err) {
       broker.log.error('handleDeProvisionRequest - %j', err);
@@ -393,13 +371,51 @@ Handlers.handleDeProvisionRequest = function(broker, req, res, next) {
       res.send(HttpStatus.GONE, {});
       broker.log.info('handleDeProvisionRequest - (instanceId: %s) does not exist in broker database.', instanceId);
       return next();
-      
     }
 
     var operation = 'deprovision';
     var params = req.params;
     params.provisioning_result = serviceInstance.provisioning_result;
     params.azure = credentialsAndSubscriptionId;
+    var processResponse = function(error, reply, result) {
+      if (error) {
+        broker.log.error('handleDeProvisionRequest - Failed in sending deprovision request for (instanceId: %s) to Azure. Deprovision Error: %j', instanceId, error);
+        res.send(error.statusCode, error);
+  
+        broker.log.info('handleDeProvisionRequest - Succeeded in sending the deprovision error response for (instanceId: %s) to cc.', instanceId);
+        return next();
+      }
+  
+      var status = serviceInstance['status'];
+      if (status == 'success') {
+        broker.log.info('handleDeProvisionRequest - The status of the service instance %s is "success". Updating the lastOperation to "deprovision" in db.', instanceId);
+        broker.db.updateServiceInstanceLastOperation(instanceId, 'deprovision', function(err){
+          if (err) {
+            broker.log.error('handleDeProvisionRequest - %j', err);
+            res.send(err.statusCode, err);
+            return next();
+          }
+
+          res.send(HttpStatus.ACCEPTED, reply.value);
+          broker.log.info('handleDeProvisionRequest - Succeeded in sending the deprovision response for (instanceId: %s) to cc.', instanceId);
+          return next();
+        });
+      } else {
+        // When the provisioning operation times out, CC will call deprovisioning to delete the orphan instance on Azure. We need to delete the service instance information in the database.
+        broker.log.warn('handleDeProvisionRequest - The status of the service instance %s is %s. The provisioning operation may have timed out. Try to delete the service instance information in db', instanceId, status);
+        broker.db.deleteServiceInstance(instanceId, function(err){
+          if (err) {
+            broker.log.error('handleDeProvisionRequest - db.deleteServiceInstance: %j', err);
+            res.send(err.statusCode, err);
+            return next();
+          }
+
+          res.send(HttpStatus.ACCEPTED, reply.value);
+          broker.log.info('handleDeProvisionRequest - Succeeded in sending the deprovision response for (instanceId: %s) to cc.', instanceId);
+          return next();
+        });
+      }
+    };
     emitEvent(broker, operation, params, processResponse, next);
   });
 };


### PR DESCRIPTION
When the provisioning operation times out, CC will call deprovisioning to delete the orphan instance on Azure. We need to delete the service instance information in the database.