### PR TITLE
Retrieve FQDN from Azure to build the correct jdbcUrl

### DIFF
--- a/lib/services/azuresqldb/cmd-serverInfo.js
+++ b/lib/services/azuresqldb/cmd-serverInfo.js
@@ -1,0 +1,67 @@
+/* jshint camelcase: false */
+/* jshint newcap: false */
+
+var _ = require('underscore');
+var async = require('async');
+var HttpStatus = require('http-status-codes');
+var util = require('util');
+
+var sqlServerPoll = function (log, params) {
+
+    var instanceId = params.instance_id;
+    var reqParams = params.parameters || {};
+    var lastoperation = params.last_operation || '';
+    var resourceGroupName = reqParams.resourceGroup || '';
+    var sqldbName = reqParams.sqldbName || '';
+    var sqlServerName = reqParams.sqlServerName || '';
+
+    log.info(util.format('sqldb cmd-serverInfo: resourceGroupName: %s, sqldbName: %s, sqlServerName: %s', resourceGroupName, sqldbName, sqlServerName));
+
+    var parametersDefined = !(_.isNull(reqParams.parameters) || _.isUndefined(reqParams.parameters));
+
+    var location = '';
+    if (parametersDefined)
+        location = reqParams.parameters.location || '';
+
+    this.serverInfo = function (sqldbOperations, next) {
+
+        var groupParameters = {
+            location: location
+        };
+
+        async.waterfall([
+            function (callback) {
+                log.info('sqldb cmd-serverInfo: async.waterfall/getToken');
+                sqldbOperations.getToken(function (err, accessToken) {
+                    if (err) {
+                        log.error('sqldb cmd-serverInfo: async.waterfall/getToken: err: %j', err);
+                        return callback(err);
+                    } else {
+                        sqldbOperations.setParameters(accessToken, resourceGroupName, sqlServerName, sqldbName);
+                        callback(null);
+                    }
+                });
+            },
+            function (callback) {   // get status of server
+                log.info('sqldb cmd-serverInfo: async.waterfall/check existence of server');
+                sqldbOperations.getServer({}, function (err, result) {
+                    if (err) {
+                        log.error('sqldb cmd-serverInfo: async.waterfall/check existence of sql server: err: %j', err);
+                        callback(err);
+                    } else {
+                        log.info('sqldb cmd-serverInfo: async.waterfall/check existence of sql server: result: %j', result);
+                        callback(null, result);
+                    }
+                });
+            }
+        ], function (err, result) {
+            log.info('sqldb cmd-serverInfo: async.waterfall/final callback: result: ', result);
+            next(err, result);
+        });
+
+    };
+
+};
+
+module.exports = sqlServerPoll;
+

--- a/lib/services/azuresqldb/index.js
+++ b/lib/services/azuresqldb/index.js
@@ -9,6 +9,7 @@ var Config = require('./service');
 var cmdDeprovision = require('./cmd-deprovision');
 var cmdProvision = require('./cmd-provision');
 var cmdPoll = require('./cmd-poll');
+var cmdServerInfo = require('./cmd-serverInfo.js');
 var sqldbOperations = require('./client');
 var resourceGroupClient = require('../../common/resourceGroup-client');
 var Reply = require('../../common/reply');
@@ -101,29 +102,42 @@ Handlers.bind = function (log, params, next) {
 
   log.info('sqldb/index/bind/params: %j', params);
 
-  var provisioningResult = JSON.parse(params.provisioning_result);
+  var lastOperation = params.last_operation;
+  var cp = new cmdServerInfo(log, params);
+  var sqldbOps = new sqldbOperations(log, params.azure);
+  cp.serverInfo(sqldbOps, function (err, result) {
+    if (err) {
+      common.handleServiceError(log, err, next);
+    } else if (result.statusCode === HttpStatus.OK) {
+      var provisioningResult = JSON.parse(params.provisioning_result);
+      var serverInfo = JSON.parse( result.body );
 
-  // Spring Cloud Connector Support
-  var jdbcUrl = 'jdbc:sqlserver://' + provisioningResult.sqlServerName + '.database.windows.net:1433;database=' +
-      provisioningResult.name + ';user=' + provisioningResult.administratorLogin + ';password=' +
-      provisioningResult.administratorLoginPassword;
+      // Spring Cloud Connector Support
+      var jdbcUrl = 'jdbc:sqlserver://' + serverInfo.properties.fullyQualifiedDomainName + ':1433;database=' +
+          provisioningResult.name + ';user=' + provisioningResult.administratorLogin + ';password=' +
+          provisioningResult.administratorLoginPassword;
 
-  // contents of reply.value winds up in VCAP_SERVICES
-  var reply = {
-    statusCode: HttpStatus.CREATED,
-    code: HttpStatus.getStatusText(HttpStatus.CREATED),
-    value: {
-      credentials: {
-        sqldbName: provisioningResult.name,
-        sqlServerName: provisioningResult.sqlServerName,
-        administratorLogin: provisioningResult.administratorLogin,
-        administratorLoginPassword: provisioningResult.administratorLoginPassword,
-        jdbcUrl: jdbcUrl
-      }
+      // contents of reply.value winds up in VCAP_SERVICES
+      var reply = {
+        statusCode: HttpStatus.CREATED,
+        code: HttpStatus.getStatusText(HttpStatus.CREATED),
+        value: {
+          credentials: {
+            sqldbName: provisioningResult.name,
+            sqlServerName: provisioningResult.sqlServerName,
+            administratorLogin: provisioningResult.administratorLogin,
+            administratorLoginPassword: provisioningResult.administratorLoginPassword,
+            jdbcUrl: jdbcUrl
+          }
+        }
+      };
+
+      next(null, reply, {});
+
+    } else {
+      next(null, lastOperation, { statusCode: result.statusCode, value: result.value }, null);
     }
-  };
-
-  next(null, reply, {});
+  });
 
 };
 


### PR DESCRIPTION
I messed up pull request 45 on my rebase attempt, so I am resubmitting it cleanly here.

On service binding, retrieve the FQDN of the provisioned Azure SQL server instead of hardcoding the server name.

Tested against AzureCloud, but not AzureChinaCloud.

Fixes #35