### PR TITLE
Don't use "then...catch..." to avoid catching the errors outside

### DIFF
--- a/lib/broker/db/sqlserver/sqlserver.js
+++ b/lib/broker/db/sqlserver/sqlserver.js
@@ -11,27 +11,20 @@ function executeSql(config, sql, callback, retry, retryInterval) {
   if (!(typeof retryInterval === 'number' && (retryInterval%1) === 0)) {
     retryInterval = 1000;
   }
-  var conn = new sqlDb.Connection(config);
-  conn.connect()
-    .then(function() {
-      var req = new sqlDb.Request(conn);
-      req.query(sql)
-        .then(function(recordset) {
-          callback(null, recordset);
-          conn.close();
-        })
-        .catch(function(err) {
-          callback(err, null);
-          conn.close();
-        });
-    })
-    .catch(function(err) {
+  var conn = sqlDb.connect(config, function(err) {
+    if (err) {
       if (retry === 0) {
-        callback(err, null);
+        return callback(err);
       } else {
-        setTimeout(function(){executeSql(config, sql, callback, retry-1, retryInterval);}, retryInterval);
+        return setTimeout(executeSql(config, sql, callback, retry-1, retryInterval), retryInterval);
       }
+    }
+    var req = new sqlDb.Request(conn);
+    req.query(sql, function(err, recordset) {
+      conn.close();
+      callback(err, recordset);
     });
+  });
 };
 
 exports.executeSqlWithParameters =
@@ -42,26 +35,19 @@ function executeSqlWithParameters(config, sql, parameters, callback, retry, retr
   if (!(typeof retryInterval === 'number' && (retryInterval%1) === 0)) {
     retryInterval = 1000;
   }
-  var conn = new sqlDb.Connection(config);
-  conn.connect()
-    .then(function() {
-      var req = new sqlDb.Request(conn);
-      req.input('parameters', parameters);
-      req.query(sql)
-        .then(function(recordset) {
-          callback(null, recordset);
-          conn.close();
-        })
-        .catch(function(err) {
-          callback(err, null);
-          conn.close();
-        });
-    })
-    .catch(function(err) {
+  var conn = sqlDb.connect(config, function(err){
+    if (err) {
       if (retry === 0) {
-        callback(err, null);
+        return callback(err);
       } else {
-        setTimeout(function(){executeSqlWithParameters(config, sql, parameters, callback, retry-1, retryInterval);}, retryInterval);
+        return setTimeout(executeSqlWithParameters(config, sql, parameters, callback, retry-1, retryInterval), retryInterval);
       }
+    }
+    var req = new sqlDb.Request(conn);
+    req.input('parameters', parameters);
+    req.query(sql, function(err, recordset) {
+      conn.close();  
+      callback(err, recordset);
     });
+  });
 };


### PR DESCRIPTION
Previously, the error outside `lib/broker/db/sqlserver/sqlserver.js` may be caught by the `then...catch...` logic.
For example,
```
Failed in finding the record by (instanceId: cebd9505-7b1f-43e6-9660-aa4223f82ea6) in the broker database. DB Error: {}
```
`getServiceInstance` failed when it tried to find the record. The error is empty. In fact, the logic of finding the record in `lib/broker/db/sqlserver/sqlserver.js` does not throw an error. But the logic in `getServiceInstance` throws an error, and it's caught by `lib/broker/db/sqlserver/sqlserver.js`.

This PR fixes this issue.