### PR TITLE
Refining azure-sqldb, and upgrading the tile to v1.2.1

### DIFF
--- a/docs/azure-sql-db.md
+++ b/docs/azure-sql-db.md
@@ -214,16 +214,19 @@
 
   ```
   "credentials": {
+    "sqldbName": "sqlDbA",
+    "sqlServerName": "sqlservera",
+    "sqlServerFullyQualifiedDomainName": "fake-server.database.windows.net",
     "databaseLogin": "ulrich",
     "databaseLoginPassword": "u1r8chP@ss",
-    "sqlServerName": "sqlservera",
-    "sqldbName": "sqlDbA",
-    "jdbcUrl": "jdbc:sqlserver://fake-server.database.windows.net:1433;database=fake-database;user=fake-admin;password=fake-password",
-    
+    "jdbcUrl": "jdbc:sqlserver://fake-server.database.windows.net:1433;database=fake-database;user=fake-admin;password=fake-password;Encrypt=true;TrustServerCertificate=false;HostNameInCertificate=*.database.windows.net;loginTimeout=30",
+    "jdbcUrlForAuditingEnabled": jdbc:sqlserver://fake-server.database.secure.windows.net:1433;database=fake-database;user=fake-admin;password=fake-password;Encrypt=true;TrustServerCertificate=false;HostNameInCertificate=*.database.secure.windows.net;loginTimeout=30"
   }
 
   ```
-
+  
+  **NOTE**: The "jdbcUrl" is for auditing disabled only. Similarly, the "jdbcUrlForAuditingEnabled" is for auditing enabled only. [Here](https://docs.microsoft.com/en-us/azure/sql-database/sql-database-auditing-and-dynamic-data-masking-downlevel-clients) is a doc about why.
+  
 ## Unbinding
 
   ```

--- a/lib/common/index.js
+++ b/lib/common/index.js
@@ -62,7 +62,7 @@ module.exports.getConfigurations = function() {
     },
     'privilege': {
         'sqldb': {
-            'allowToCreateSqlServer': process.env['AZURE_SQLDB_ALLOW_TO_CREATE_SQL_SERVER'],
+            'allowToCreateSqlServer': (process.env['AZURE_SQLDB_ALLOW_TO_CREATE_SQL_SERVER'] === undefined || process.env['AZURE_SQLDB_ALLOW_TO_CREATE_SQL_SERVER'] === 'true'),
         }
     },
     'accountPool': {
@@ -71,23 +71,6 @@ module.exports.getConfigurations = function() {
     }
   };
   
-  // set undefined with default vaules
-  var defaultPrivilege = {
-      'sqldb': {
-          'allowToCreateSqlServer': true
-      }
-  };
-  for (var moduleName in config['privilege']) if (config['privilege'].hasOwnProperty(moduleName)) {
-      var module = config['privilege'][moduleName];
-      for (var opt in module) if (module.hasOwnProperty(opt)) {
-          if (module[opt] === undefined) {
-              module[opt] = defaultPrivilege[moduleName][opt];
-          } else if (module[opt].toLowerCase() === 'false') {
-              module[opt] = false;
-          }
-      }
-  }
-  
   // import sql admin accounts
   if (process.env['AZURE_SQLDB_SQL_SERVER_POOL']) {
           
@@ -95,12 +78,25 @@ module.exports.getConfigurations = function() {
       try {
           var sqlServers = JSON.parse(process.env['AZURE_SQLDB_SQL_SERVER_POOL']);
           sqlServers.forEach(function(sqlServer){
-              if (!(sqlServer['sqlServerName'] && sqlServer['administratorLogin'] && sqlServer['administratorLoginPassword'])) {
-                  throw Error('Incomplete credentials for some servers.');
+              var serverName = sqlServer['sqlServerName'];
+              var login = sqlServer['administratorLogin'];
+              var pwd = sqlServer['administratorLoginPassword'];
+              if (!(serverName && login && pwd)) {
+                  throw Error('Incomplete credentials for some sql servers.');
               }
-              sqlServerPool[sqlServer['sqlServerName']] = {
-                  administratorLogin: sqlServer['administratorLogin'],
-                  administratorLoginPassword: sqlServer['administratorLoginPassword']
+                
+              // pcf-tile pass the value of administratorLoginPassword as {"secret": "<password>"}
+              if (typeof pwd === 'object') {
+                pwd = pwd.secret;
+              }
+              
+              if (typeof serverName !== 'string' || typeof login !== 'string' || typeof pwd !== 'string') {
+                throw Error('Please check your sql server credentials.');
+              }
+              
+              sqlServerPool[serverName] = {
+                  administratorLogin: login,
+                  administratorLoginPassword: pwd
               };
           });
       } catch (e) {

--- a/lib/services/azuresqldb/client.js
+++ b/lib/services/azuresqldb/client.js
@@ -261,10 +261,10 @@ sqldbOperations.prototype.executeSql = function (config, sql, isDeleteFirewallRu
                 that.log.info('sqldb: failed to login server: %s', err);
                 that.log.info('sqldb: It is going to create a temp firewall rule');
                 
-                //example message: 'Cannot open server \'asdasd\' requested by the login. Client with IP address \'168.61.65.103\' is not allowed to access the server.  To enable access, use the Windows Azure Management Portal or run sp_set_firewall_rule on the master database to create a firewall rule for this IP address or address range.  It may take up to five minutes for this change to take effect.'
-                var runnerIp = err.message.match(/\d+\.\d+\.\d+\.\d+/)[0];
+                //example message: 'Cannot open server \'asdasd\' requested by the login. Client with IP address \'168.61.65.xxx\' is not allowed to access the server.  To enable access, use the Windows Azure Management Portal or run sp_set_firewall_rule on the master database to create a firewall rule for this IP address or address range.  It may take up to five minutes for this change to take effect.'
+                var runnerIpPrefix = err.message.match(/\d+\.\d+\.\d+\./)[0];
 
-                return that.createFirewallRule(tempFirewallRuleName, runnerIp, runnerIp, function(err, result){
+                return that.createFirewallRule(tempFirewallRuleName, runnerIpPrefix + '0', runnerIpPrefix + '255', function(err, result){
                     if (err) {
                         that.log.error('sqldb: create temp firewall rule: err: %j', err);
                         callback(err);

--- a/lib/services/azuresqldb/cmd-provision.js
+++ b/lib/services/azuresqldb/cmd-provision.js
@@ -80,7 +80,7 @@ var sqldbProvision = function (log, params) {
                 administratorLogin = accountPool[sqlServerName]['administratorLogin'];
                 administratorLoginPassword = accountPool[sqlServerName]['administratorLoginPassword'];
             } else {
-                var errorMessage = util.format('Both administratorLogin and administratorLoginPassword must be provided for the SQL server %s.', sqlServerName);
+                var errorMessage = util.format('Can\'t find credentials of the SQL server %s.', sqlServerName);
                 return next(Error(errorMessage));
             }
         }

--- a/lib/services/azuresqldb/index.js
+++ b/lib/services/azuresqldb/index.js
@@ -4,6 +4,7 @@
 'use strict';
 
 var _ = require('underscore');
+var util = require('util');
 var HttpStatus = require('http-status-codes');
 var Config = require('./service');
 var cmdDeprovision = require('./cmd-deprovision');
@@ -112,11 +113,32 @@ Handlers.bind = function (log, params, next) {
     } else {
       var provisioningResult = JSON.parse(params.provisioning_result);
 
+      var fqdn = provisioningResult.fullyQualifiedDomainName;
       // Spring Cloud Connector Support
-      var jdbcUrl = 'jdbc:sqlserver://' + provisioningResult.fullyQualifiedDomainName + ':1433;database=' +
-          provisioningResult.name + ';user=' + result.databaseLogin + ';password=' +
-          result.databaseLoginPassword;
-
+      var jdbcUrlTemplate = 'jdbc:sqlserver://%s:1433;' + 
+                            'database=%s;' +
+                            'user=%s;' + 
+                            'password=%s;' +
+                            'Encrypt=true;' +
+                            'TrustServerCertificate=false;' +
+                            'HostNameInCertificate=%s;' +
+                            'loginTimeout=30;';
+      
+      var jdbcUrl = util.format(jdbcUrlTemplate,
+                                fqdn,
+                                provisioningResult.name,
+                                result.databaseLogin,
+                                result.databaseLoginPassword,
+                                fqdn.replace(/.+\.database/, '*.database'));
+      
+      // Differences between auditing enabled and disabled: https://docs.microsoft.com/en-us/azure/sql-database/sql-database-auditing-and-dynamic-data-masking-downlevel-clients
+      var jdbcUrlForAuditingEnabled = util.format(jdbcUrlTemplate,
+                                fqdn.replace(/\.database/, '.database.secure'),
+                                provisioningResult.name,
+                                result.databaseLogin,
+                                result.databaseLoginPassword,
+                                fqdn.replace(/.+\.database/, '*.database.secure'));
+                      
       // contents of reply.value winds up in VCAP_SERVICES
       var reply = {
         statusCode: HttpStatus.CREATED,
@@ -125,9 +147,11 @@ Handlers.bind = function (log, params, next) {
           credentials: {
             sqldbName: provisioningResult.name,
             sqlServerName: provisioningResult.sqlServerName,
+            sqlServerFullyQualifiedDomainName: fqdn,
             databaseLogin: result.databaseLogin,
             databaseLoginPassword: result.databaseLoginPassword,
-            jdbcUrl: jdbcUrl
+            jdbcUrl: jdbcUrl,
+            jdbcUrlForAuditingEnabled: jdbcUrlForAuditingEnabled
           }
         }
       };

--- a/pcf-tile/tile-history.yml
+++ b/pcf-tile/tile-history.yml
@@ -2,4 +2,5 @@
 history:
 - 1.0.0
 - 1.1.0
-version: 1.2.0
+- 1.2.0
+version: 1.2.1

--- a/pcf-tile/tile.yml
+++ b/pcf-tile/tile.yml
@@ -112,7 +112,29 @@ forms:
   - name: azure_broker_database_encryption_key
     type: secret
     label: Database Encryption Key (32 characters)
-
+- name: sqldb-config-form
+  label: SQL Database Config
+  properties:
+  - name: azure_sqldb_allow_to_create_sql_server
+    type: boolean
+    configurable: true
+    default: true
+    label: Allow to Create Sql Server
+  - name: azure_sqldb_sql_server_pool
+    type: collection
+    configurable: true
+    property_blueprints:
+      - name: sqlServerName
+        type: string
+        label: SQL Server Name
+      - name: administratorLogin
+        type: string
+        label: SQL Server Administrator Login
+      - name: administratorLoginPassword
+        type: secret
+        label: SQL Server Administrator Login Password
+    label: Sql Server Pool
+    
 # Add any dependencies your tile has on other installed products.
 # This is often appropriate when using automatic service provisioning
 # for any of your packages above, with services provided by other

--- a/test/integration/submatrix/sqldb.js
+++ b/test/integration/submatrix/sqldb.js
@@ -66,8 +66,10 @@ azuresqldb = {
     "databaseLogin": "<string>",
     "databaseLoginPassword": "<string>",
     "sqlServerName": sqlServerName,
+    "sqlServerFullyQualifiedDomainName": "<string>",
     "sqldbName": sqldbName,
-    "jdbcUrl": "<string>"
+    "jdbcUrl": "<string>",
+    "jdbcUrlForAuditingEnabled": "<string>"
   },
   e2e: false
 }
@@ -120,8 +122,10 @@ azuresqldb = {
     "databaseLogin": "<string>",
     "databaseLoginPassword": "<string>",
     "sqlServerName": sqlServerName,
+    "sqlServerFullyQualifiedDomainName": "<string>",
     "sqldbName": sqldbName,
-    "jdbcUrl": "<string>"
+    "jdbcUrl": "<string>",
+    "jdbcUrlForAuditingEnabled": "<string>"
   },
   e2e: true
 }


### PR DESCRIPTION
* Refine `jdbcUrl` in the module `azure-sqldb`
  * Append more options `Encrypt=true;TrustServerCertificate=false;HostNameInCertificate=*.database.windows.net;loginTimeout=30` to keep consistent with Azure Portal.
  * Add `jdbcUrlForAuditingEnabled`. It should be used when auditing is enabled.
* Fix the issue of the allowed IP in the temporary firewall rule
  * Adapt the change of error message returned from SQL Server.
* Upgrade tile:
  * Add a new config form for `AZURE_SQLDB_ALLOW_TO_CREATE_SQL_SERVER` and `AZURE_SQLDB_SQL_SERVER_POOL`
  * Upgrade the stemcell version to the latest
* Refine the doc of azure-sqldb
  * Describe the behaviors clearer