### PR TITLE
set AZURE_SQLDB_SQL_SERVER_POOL optional in tile.yml

### DIFF
--- a/pcf-tile/tile.yml
+++ b/pcf-tile/tile.yml
@@ -123,6 +123,7 @@ forms:
   - name: azure_sqldb_sql_server_pool
     type: collection
     configurable: true
+    optional: true
     property_blueprints:
       - name: sqlServerName
         type: string


### PR DESCRIPTION
When installing the tile, users don't need to input `AZURE_SQLDB_SQL_SERVER_POOL` if `azure_sqldb_allow_to_create_sql_server` is `true`.