### PR TITLE
make broker deployable to k8s via helm

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,14 @@
 language: node_js
-sudo: false
+services:
+- docker
+sudo: required
 node_js:
 - '4.2'
 script:
 - npm test
+- make docker-build
+deploy:
+  provider: script
+  script: scripts/deploy.sh
+  on:
+    branch: master

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM node:7.9.0
+
+# Create app directory
+RUN mkdir -p /usr/src/app
+WORKDIR /usr/src/app
+
+# Install app source
+COPY . /usr/src/app/
+
+# Install dependencies
+RUN npm install
+
+EXPOSE 5001
+CMD [ "npm", "start" ]
+
+ARG VERSION
+ARG BUILD_DATE
+ENV VERSION $VERSION
+ENV BUILD_DATE $BUILD_DATE

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,13 @@
+BASE_NAME     = meta-azure-service-broker
+VERSION      ?= $(shell git describe --always --abbrev=7 --dirty)
+MUTABLE_TAG  ?= canary
+IMAGE         = $(REGISTRY)$(BASE_NAME):$(VERSION)
+MUTABLE_IMAGE = $(REGISTRY)$(BASE_NAME):$(MUTABLE_TAG)
+
+docker-build:
+	docker build -t $(IMAGE) .
+	docker tag $(IMAGE) $(MUTABLE_IMAGE)
+
+docker-push: docker-build
+	docker push $(IMAGE)
+	docker push $(MUTABLE_IMAGE)

--- a/charts/meta-azure-service-broker/Chart.yaml
+++ b/charts/meta-azure-service-broker/Chart.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+description: A Helm chart for the Azure Meta Service Broker
+name: meta-azure-service-broker
+version: 0.1.0

--- a/charts/meta-azure-service-broker/templates/_helpers.tpl
+++ b/charts/meta-azure-service-broker/templates/_helpers.tpl
@@ -1,0 +1,16 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/charts/meta-azure-service-broker/templates/cert-secret.yaml
+++ b/charts/meta-azure-service-broker/templates/cert-secret.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.ingress.tls.enabled }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "fullname" . }}-cert
+  labels:
+    app: {{ template "fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+type: Opaque
+data:
+  tls.crt: {{ required "When ingress with TLS is enabled, a value is required for ingress.tls.cert" .Values.ingress.tls.cert }}
+  tls.key: {{ required "When ingress with TLS is enabled, a value is required for ingress.tls.key" .Values.ingress.tls.key }}
+{{- end }}

--- a/charts/meta-azure-service-broker/templates/deployment.yaml
+++ b/charts/meta-azure-service-broker/templates/deployment.yaml
@@ -1,0 +1,90 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: {{ template "fullname" . }}
+  labels:
+    app: {{ template "fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ template "fullname" . }}
+  template:
+    metadata:
+      labels:
+        app: {{ template "fullname" . }}
+        chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+        release: "{{ .Release.Name }}"
+        heritage: "{{ .Release.Service }}"
+    spec:
+      containers:
+      - name: meta-azure-service-broker
+        image: {{ required "A value is required for image.repository" .Values.image.repository }}:{{ .Values.image.tag }}
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        resources:
+          requests:
+            cpu: 100m
+            memory: 128Mi
+          limits:
+            cpu: 100m
+            memory: 256Mi
+        env:
+        - name: ENVIRONMENT
+          value: {{ .Values.config.azure.environment }}
+        - name: SUBSCRIPTION_ID
+          value: {{ required "A value is required for config.azure.subscriptionId" .Values.config.azure.subscriptionId }}
+        - name: TENANT_ID
+          value: {{ required "A value is required for config.azure.servicePrincipal.tenantId" .Values.config.azure.servicePrincipal.tenantId }}
+        - name: CLIENT_ID
+          value: {{ required "A value is required for config.azure.servicePrincipal.clientId" .Values.config.azure.servicePrincipal.clientId }}
+        - name: CLIENT_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: {{ template "fullname" . }}
+              key: client-secret
+        - name: SECURITY_USER_NAME
+          value: {{ required "A value is required for config.auth.username" .Values.config.auth.username }}
+        - name: SECURITY_USER_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ template "fullname" . }}
+              key: auth-password
+        - name: AZURE_BROKER_DATABASE_PROVIDER
+          value: sqlserver
+        - name: AZURE_BROKER_DATABASE_SERVER
+          value: {{ required "A value is required for config.database.host" .Values.config.database.host }}
+        - name: AZURE_BROKER_DATABASE_USER
+          value: {{ required "A value is required for config.database.username" .Values.config.database.username }}
+        - name: AZURE_BROKER_DATABASE_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ template "fullname" . }}
+              key: db-password
+        - name: AZURE_BROKER_DATABASE_NAME
+          value: {{ required "A value is required for config.database.dbName" .Values.config.database.dbName }}
+        - name: AZURE_BROKER_DATABASE_ENCRYPTION_KEY
+          valueFrom:
+            secretKeyRef:
+              name: {{ template "fullname" . }}
+              key: db-encryption-key 
+        ports:
+        - containerPort: 5001
+        readinessProbe:
+          tcpSocket:
+            port: 5001
+          failureThreshold: 1
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 2
+        livenessProbe:
+          tcpSocket:
+            port: 5001
+          failureThreshold: 3
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 2

--- a/charts/meta-azure-service-broker/templates/ingress.yaml
+++ b/charts/meta-azure-service-broker/templates/ingress.yaml
@@ -1,0 +1,30 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ template "fullname" . }}
+  labels:
+    app: {{ template "fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+  annotations:
+  {{- range $key, $value := .Values.ingress.annotations }}
+    {{ $key }}: {{ quote $value }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.tls.enabled }}
+  tls:
+  - hosts:
+    - {{ required "When ingress is enabled, a value is required for ingress.domain" .Values.ingress.domain }}
+    secretName: {{ template "fullname" . }}-cert
+  {{- end }}
+  rules:
+  - host: {{ required "When ingress is enabled, a value is required for ingress.domain" .Values.ingress.domain }}
+    http:
+      paths:
+      - path: /
+        backend:
+          serviceName: {{ template "fullname" . }}
+          servicePort: http
+{{- end }}

--- a/charts/meta-azure-service-broker/templates/secret.yaml
+++ b/charts/meta-azure-service-broker/templates/secret.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "fullname" . }}
+  labels:
+    app: {{ template "fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+data:
+  client-secret: {{ required "A value is required for config.azure.servicePrincipal.clientSecret" .Values.config.azure.servicePrincipal.clientSecret | b64enc }}
+  auth-password: {{ required "A value is required for config.auth.password" .Values.config.auth.password | b64enc }}
+  db-password: {{ required "A value is required for config.database.password" .Values.config.database.password | b64enc }}
+  db-encryption-key: {{ required "A value is required for config.database.encryptionKey" .Values.config.database.encryptionKey | b64enc }}

--- a/charts/meta-azure-service-broker/templates/service.yaml
+++ b/charts/meta-azure-service-broker/templates/service.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "fullname" . }}
+  labels:
+    app: {{ template "fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+spec:
+  type: {{ .Values.service.type }}
+  selector:
+    app: {{ template "fullname" . }}
+  ports:
+  - name: http
+    protocol: TCP
+    port: 80
+    {{- if eq .Values.service.type "NodePort" }}
+    nodePort: {{ .Values.service.nodePort.port }}
+    {{- end }}
+    targetPort: 5001

--- a/charts/meta-azure-service-broker/values.yaml
+++ b/charts/meta-azure-service-broker/values.yaml
@@ -1,0 +1,72 @@
+# Default values for meta-azure-service-broker.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+replicaCount: 1
+image:
+  # Image location, NOT including the tag
+  # Current required; value depends where you have pushed the image to. There
+  # is no default as we're not currently publishing pre-built images.
+  repository:
+  # Image tag
+  tag: canary
+  # "IfNotPresent", "Always", or "Never"; use "Always" if using a mutable image
+  pullPolicy: Always
+service:
+  # Type of service; valid values are "ClusterIP", LoadBalancer", and
+  # "NodePort". "ClusterIP" is sufficient in the average case where a service
+  # catalog installation in the same cluster is the only client that needs to
+  # communicate with this broker. i.e. The broker does not need to receive
+  # inbound requests from outside the cluster.
+  type: ClusterIP
+  # Further configuration if service is of type "NodePort"
+  nodePort:
+    # Available port in allowable range (e.g. 30000 - 32767 on minikube)
+    port: 30080
+ingress:
+  enabled: false
+  annotations: {}
+  # # domain is required if ingress is enabled
+  # # DO NOT USE THIS EXAMPLE VALUE IN PRODUCTION
+  # domain: meta-azure-service-broker.contoso.com
+  tls:
+    enabled: false
+    # # Base64-encoded certificate is required if ingress and tls are enabled
+    # # DO NOT USE THIS EXAMPLE VALUE IN PRODUCTION
+    # cert: TODO: Add base64-encoded, self-signed cert
+    # # Base64-encoded private key is required if ingress and tls are enabled
+    # # DO NOT USE THIS EXAMPLE VALUE IN PRODUCTION
+    # key: TODO: Add base64-encoded key
+config:
+  azure:
+    # Valid values are "AzureCloud" and "AzureChinaCloud"
+    environment: AzureCloud
+    # Azure subscription ID
+    subscriptionId:
+    # Azure service principal (credentials for the above subscription)
+    servicePrincipal:
+      # Required
+      tenantId:
+      # Required
+      clientId:
+      # Required
+      clientSecret:
+  # Basic auth credentials that can later be used to access this broker
+  auth:
+    # Required
+    username:
+    # Required
+    password:
+  # Only SQL Server is currently supported.
+  database:
+    # Required
+    host:
+    # Required
+    dbName:
+    # Required
+    username:
+    # Required
+    password:
+    # # A 256 bit key used for database encryption; required
+    # # NB: 32 ascii characters == 256 bits
+    # # DO NOT USE THIS EXAMPLE VALUE IN PRODUCTION
+    # encryptionKey: This is a key that is 256 bits!!

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,0 +1,15 @@
+set -o errexit
+set -o nounset
+set -o pipefail
+
+export REGISTRY=microsoft/
+
+docker login -u "${DOCKER_USERNAME}" -p "${DOCKER_PASSWORD}"
+
+if [[ -n "${TRAVIS_TAG}" ]]; then
+    echo "Pushing images with tag ${TRAVIS_TAG}."
+    VERSION="${TRAVIS_TAG}" make docker-push
+elif [[ "${TRAVIS_PULL_REQUEST}" == "false" && "${TRAVIS_BRANCH}" == "master" ]]; then
+    echo "Pushing images with sha tag."
+    make make docker-push
+fi


### PR DESCRIPTION
__Do not bother reading through this PR. I am closing it. See rational here: https://github.com/Azure/meta-azure-service-broker/pull/97#issuecomment-298718076__

Fixes #96 

This is a first pass at this. The Docker build works and so does the Helm chart. If you guys like the direction, I'd be happy to follow up with documentation and other improvements-- either as amendments to this PR or as follow-up PRs.

## Pre-requisites

- Docker is installed
- You have a running Kubernetes cluster (e.g. minikube or ACS)
- `kubectl` properly configured to interact with that cluster
- [`helm`](https://helm.sh) (the Kubernetes package manager) is installed. I tested this chart using Helm v2.3.0.

## Build the Docker image

__Note:__ These steps can be bypassed in some future state where we publish pre-built (by CI) images to some MS-owned Docker registry. (I'm new here-- not sure if there's an existing/preferred public MS/Azure Docker registry.)

For now, set the `REGISTRY` environment variable to a Docker registry you are already authenticated to and able to push to. Include a trailing slash. Examples:

- `krancour/` (my account on Docker Hub)
- `quay.io/krancour/` (my account on quay.io)
- `192.168.99.101:5000/` (a local registry; itself running in Docker)

__Note:__ Your Kubernetes cluster must _also_ be able to pull images from the registry you push to.

Build and push:

```
[meta-azure-service-broker]$ make docker-build docker-push
```

## Install the Helm chart

Make sure Tiller (the server-side component of Helm) is installed to your cluster:

```
[meta-azure-service-broker]$ helm init
```

When `helm version` shows output like the following, you're ready to roll:

```
[meta-azure-service-broker]$ helm version
Client: &version.Version{SemVer:"v2.3.0", GitCommit:"d83c245fc324117885ed83afc90ac74afed271b4", GitTreeState:"clean"}
Server: &version.Version{SemVer:"v2.3.0", GitCommit:"d83c245fc324117885ed83afc90ac74afed271b4", GitTreeState:"clean"}
```

There is obviously some custom configuration that must be provided. (For instance, the service principal that the broker uses is certainly not included in the default values.) You can extract the default configuration from the chart, modify it, and pass it back in during installation. If do miss any required configuration, Helm will tell you when you attempt to install.

First extract the default configuration to a file:

```
[meta-azure-service-broker]$ helm inspect values charts/meta-azure-service-broker > my-values.yaml
```

Edit `my-values.yaml` as you see fit. Fill in required values and override and default values you do not like.

Install:

```
[meta-azure-service-broker]$ helm install \
  charts/meta-azure-service-broker \
  --name az-broker \
  --namespace az-broker \ 
  --values my-values.yaml
```

Soon afterwards, you should be able to observe a new pod running the Meta Azure Service Broker:

```
[meta-azure-service-broker]$ kubectl get pods --namespace az-broker
NAME                                                  READY     STATUS    RESTARTS   AGE
az-broker-meta-azure-service-broker-368218162-5n22w   0/1       Running   0          10s
```

You can follow the logs for the pod whose name you discovered above to assert that the Meta Azure Service Broker has come up clean in Kubernetes:

```
[meta-azure-service-broker]$ kubectl log -f <pod name> --namespace az-broker
```

You should be able to assert at this point that the simple goal of installing this broker in Kubernetes (instead of Cloud Foundry) is achieved. It's probably not necessary to go into detail about how the [Kubernetes Service Catalog](https://github.com/kubernetes-incubator/service-catalog) integrates with the running broker. (Although it _does_ work and I will soon be putting together a demo for that shows these two things working together.) 

## Clean up:

If you wish, remove the broker from your cluster:

```
[meta-azure-service-broker]$ helm delete az-broker --purge
```