### PR TITLE
Increase timeout on lifecycle test

### DIFF
--- a/test/integration/lifecycle.js
+++ b/test/integration/lifecycle.js
@@ -124,6 +124,7 @@ function runLifecycle(testMatrix) {
         });
 
         it('should validate the provisioning operation', function(done) {
+          this.timeout(60000);
           var test = this;
           if(client && client.validateProvisioning) {
             client.validateProvisioning(service, done);


### PR DESCRIPTION
The 2 second default is too short