### PR TITLE
Fix mocha config parameter

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,7 +10,7 @@
             "name": "Integration Tests",
             "program": "${workspaceRoot}/node_modules/mocha/bin/_mocha",
             "args": [
-                "--config",
+                "--opts",
                 "${workspaceRoot}/test/integration/mocha.opts",
                 "${workspaceRoot}/test/integration/catalog.js",
                 "${workspaceRoot}/test/integration/lifecycle.js"
@@ -24,7 +24,7 @@
             "name": "Unit Tests",
             "program": "${workspaceRoot}/node_modules/mocha/bin/_mocha",
             "args": [
-                "--config",
+                "--opts",
                 "${workspaceRoot}/test/unit/mocha.opts",
                 "${workspaceRoot}/test/unit/mockLogger",
                 "${workspaceRoot}/test/unit/common/",

--- a/package.json
+++ b/package.json
@@ -67,9 +67,9 @@
     "lint": "npm -s run-script jshint && npm -s run-script eslint",
     "jshint": "jshint lib test brokerserver.js --reporter=jslint",
     "eslint": "eslint --cache=true --max-warnings 0 lib test brokerserver.js",
-    "unit": "mocha --config test/unit/mocha.opts test/unit/mockLogger test/unit/common/ --recursive test/unit/services/",
-    "integration": "mocha --config test/integration/mocha.opts test/integration/catalog.js test/integration/lifecycle.js",
-    "cover": "istanbul cover ./node_modules/mocha/bin/_mocha -- --config test/unit/mocha.opts test/unit/mockLogger test/unit/common/ --recursive test/unit/services/",
+    "unit": "mocha --opts test/unit/mocha.opts test/unit/mockLogger test/unit/common/ --recursive test/unit/services/",
+    "integration": "mocha --opts test/integration/mocha.opts test/integration/catalog.js test/integration/lifecycle.js",
+    "cover": "istanbul cover ./node_modules/mocha/bin/_mocha -- --opts test/unit/mocha.opts test/unit/mockLogger test/unit/common/ --recursive test/unit/services/",
     "start": "node index.js"
   }
 }

--- a/test/integration/mocha.opts
+++ b/test/integration/mocha.opts
@@ -1,3 +1,3 @@
---ui tdd
+--ui bdd
 --timeout 200000
 --reporter list

--- a/test/unit/mocha.opts
+++ b/test/unit/mocha.opts
@@ -1,4 +1,4 @@
 --ui bdd
---timeout 20000
---reporter list
+--timeout 2000
+--reporter spec
 --colors


### PR DESCRIPTION
Arguments in mocha.opts were being ignored because the wrong flag was being passed. I could not find a way to enable warning or errors on bad flags in the doc : https://mochajs.org/#usage