### PR TITLE
fix provision-poll and deprovision bug in api-handler

### DIFF
--- a/lib/broker/v2/api-handlers.js
+++ b/lib/broker/v2/api-handlers.js
@@ -191,22 +191,13 @@ var handleProvisionPollResponse = function(error, reply, result, broker, req, re
 
   if (error) {
     log.error('handleProvisionPollResponse - Failed in polling the status for (instanceId: %s). Error: %j', instanceId, error);
-    broker.db.deleteServiceInstance(instanceId, function(err){
-      if (err) {
-        // CC will continue polling until the broker returns a valid response (200 OK) or the maximum polling duration is reached
-        log.error('handleProvisionPollResponse - db.deleteServiceInstance: %j', err);
-        res.send(err.statusCode, err);
-        return next();
-      }
-
-      var responseBody = {
-        'state': 'failed',
-        'description': util.format('%j', error)
-      };
-      res.send(HttpStatus.OK, responseBody);
-      log.info('handleProvisionPollResponse - Succeeded in sending the poll response for (instanceId: %s) to cc. State: %j', instanceId, responseBody);
-      return next();
-    });
+    var responseBody = {
+      'state': 'failed',
+      'description': util.format('%j', error)
+    };
+    res.send(HttpStatus.OK, responseBody);
+    log.info('handleProvisionPollResponse - Succeeded in sending the poll response for (instanceId: %s) to cc. State: %j', instanceId, responseBody);
+    return next();
   } else if (reply.value.state == 'succeeded') {
     log.info('handleProvisionPollResponse - Succeeded in polling the status for (instanceId: %s). State: %j', instanceId, reply);
     broker.db.updateServiceInstanceProvisioningSuccessResult(instanceId, JSON.stringify(result), function(err){
@@ -396,34 +387,18 @@ Handlers.handleDeProvisionRequest = function(broker, req, res, next) {
       }
 
       var status = serviceInstance['status'];
-      if (status == 'success') {
-        log.info('handleDeProvisionRequest - The status of the service instance %s is "success". Updating the lastOperation to "deprovision" in db.', instanceId);
-        broker.db.updateServiceInstanceLastOperation(instanceId, 'deprovision', function(err){
-          if (err) {
-            log.error('handleDeProvisionRequest - %j', err);
-            res.send(err.statusCode, err);
-            return next();
-          }
-
-          res.send(HttpStatus.ACCEPTED, reply.value);
-          log.info('handleDeProvisionRequest - Succeeded in sending the deprovision response for (instanceId: %s) to cc.', instanceId);
+      log.info('handleDeProvisionRequest - The status of the service instance %s is "%s". Updating the lastOperation to "deprovision" in db.', instanceId, status);
+      broker.db.updateServiceInstanceLastOperation(instanceId, 'deprovision', function(err){
+        if (err) {
+          log.error('handleDeProvisionRequest - %j', err);
+          res.send(err.statusCode, err);
           return next();
-        });
-      } else {
-        // When the provisioning operation times out, CC will call deprovisioning to delete the orphan instance on Azure. We need to delete the service instance information in the database.
-        log.warn('handleDeProvisionRequest - The status of the service instance %s is %s. The provisioning operation may have timed out. Try to delete the service instance information in db', instanceId, status);
-        broker.db.deleteServiceInstance(instanceId, function(err){
-          if (err) {
-            log.error('handleDeProvisionRequest - db.deleteServiceInstance: %j', err);
-            res.send(err.statusCode, err);
-            return next();
-          }
+        }
 
-          res.send(HttpStatus.ACCEPTED, reply.value);
-          log.info('handleDeProvisionRequest - Succeeded in sending the deprovision response for (instanceId: %s) to cc.', instanceId);
-          return next();
-        });
-      }
+        res.send(HttpStatus.ACCEPTED, reply.value);
+        log.info('handleDeProvisionRequest - Succeeded in sending the deprovision response for (instanceId: %s) to cc.', instanceId);
+        return next();
+      });
     };
     emitEvent(broker, operation, params, processResponse, next);
   });


### PR DESCRIPTION
Provision-poll:
   The instance info should not be deleted if polling failed. Deprovision still need it.

Deprovision:
    The  instance info should not be deleted though the status is pending. It should be deleted in deprovision-poll.