### PR TITLE
Updated to shrink plan description to valid length

### DIFF
--- a/lib/services/azurecosmosdb/service.json
+++ b/lib/services/azurecosmosdb/service.json
@@ -13,7 +13,7 @@
     "id": "19d433f0-ea86-4e81-84d1-92eb97e8a434",
     "name": "standard",
     "free":false,
-    "description": "The standard Azure CosmosDb plan. Your cost depends on your operations. Your cost  is billed hourly based on the amount of data stored (in GBs) and throughput reserved in units of 100 RUs/second: https://azure.microsoft.com/en-us/pricing/details/cosmos-db/.",
+    "description": "The standard Azure CosmosDb plan. Your cost depends on your operations. Your cost is billed hourly based on the amount of data stored (in GBs) and throughput reserved in units of 100 RUs/second: https://azure.microsoft.com/en-us/pricing/details/cosmos-db/",
     "metadata": {
       "bullets": [],
       "costs": [{


### PR DESCRIPTION
Current length is 257 characters which is invalid and causes an error when registering the broker. I subtracted a space, and removed the period at the end to get you to 255!