### PR TITLE
Just something to look at: Alternative take on Postgres

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,4 +1,5 @@
 {
+  "esversion": 6,
   "bitwise": true,
   "camelcase": true,
   "curly": false,

--- a/lib/services/azurepostgresqldb/cmd-bind.js
+++ b/lib/services/azurepostgresqldb/cmd-bind.js
@@ -2,12 +2,12 @@
 
 'use strict';
 
-const _ = require('underscore');
 const common = require('../../common');
 const Config = require('./service');
 const log = common.getLogger(Config.name);
 const util = require('util');
 const escape = require('pg-escape');
+const pgUtils = require('./pg-utils');
 
 const postgresqldbBind = function (params) {
 
@@ -23,38 +23,8 @@ const postgresqldbBind = function (params) {
   );
 
   this.bind = function (dbConnect) {
-    let uppercaseLetters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
-    let lowercaseLetters = uppercaseLetters.toLowerCase();
-    let numbers = '1234567890';
-
-    let databaseLogin = _.sample(lowercaseLetters) +
-                        _.sample(lowercaseLetters + numbers, 9).join('');
-
-    function getRandomInt (min, max) {
-      return Math.floor(Math.random() * (max - min + 1)) + min;
-    }
-
-    Array.prototype.shuffle = function() {
-      for (let i = this.length - 1; i > 0; i--) {
-        let j = Math.floor(Math.random() * (i + 1));
-        let temp = this[i];
-        this[i] = this[j];
-        this[j] = temp;
-      }
-      return this;
-    };
-
-    // Generate password
-    let passwordLength = 10;
-    let databaseLoginPassword = '';
-    let upperLength = getRandomInt(1, passwordLength-2);
-    databaseLoginPassword += _.sample(uppercaseLetters, upperLength).join('');
-    let lowerLength = getRandomInt(1, passwordLength-upperLength-1);
-    databaseLoginPassword +=  _.sample(lowercaseLetters, lowerLength).join('');
-    let numLength = passwordLength - upperLength - lowerLength;
-    databaseLoginPassword +=  _.sample(numbers, numLength).join('');
-    databaseLoginPassword = databaseLoginPassword.split('').shuffle().join('');
-
+    let databaseLogin = pgUtils.generateIdentifier();
+    let databaseLoginPassword = pgUtils.generatePassword();
     let client, chainErr;
     let transactionStarted = false;
     return dbConnect({

--- a/lib/services/azurepostgresqldb/cmd-bind.js
+++ b/lib/services/azurepostgresqldb/cmd-bind.js
@@ -1,0 +1,125 @@
+/* jshint camelcase: false */
+
+'use strict';
+
+const _ = require('underscore');
+const common = require('../../common');
+const Config = require('./service');
+const log = common.getLogger(Config.name);
+const util = require('util');
+const escape = require('pg-escape');
+
+const postgresqldbBind = function (params) {
+
+  let provisioningResult = params.provisioning_result;
+
+  log.info(
+    util.format(
+      'postgresqldb cmd-bind: resourceGroup: %s, postgresqldbName: %s, postgresqlServerName: %s',
+      provisioningResult.resourceGroup,
+      provisioningResult.postgresqldbName,
+      provisioningResult.postgresqlServerName
+    )
+  );
+
+  this.bind = function (dbConnect) {
+    let uppercaseLetters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
+    let lowercaseLetters = uppercaseLetters.toLowerCase();
+    let numbers = '1234567890';
+
+    let databaseLogin = _.sample(lowercaseLetters) +
+                        _.sample(lowercaseLetters + numbers, 9).join('');
+
+    function getRandomInt (min, max) {
+      return Math.floor(Math.random() * (max - min + 1)) + min;
+    }
+
+    Array.prototype.shuffle = function() {
+      for (let i = this.length - 1; i > 0; i--) {
+        let j = Math.floor(Math.random() * (i + 1));
+        let temp = this[i];
+        this[i] = this[j];
+        this[j] = temp;
+      }
+      return this;
+    };
+
+    // Generate password
+    let passwordLength = 10;
+    let databaseLoginPassword = '';
+    let upperLength = getRandomInt(1, passwordLength-2);
+    databaseLoginPassword += _.sample(uppercaseLetters, upperLength).join('');
+    let lowerLength = getRandomInt(1, passwordLength-upperLength-1);
+    databaseLoginPassword +=  _.sample(lowercaseLetters, lowerLength).join('');
+    let numLength = passwordLength - upperLength - lowerLength;
+    databaseLoginPassword +=  _.sample(numbers, numLength).join('');
+    databaseLoginPassword = databaseLoginPassword.split('').shuffle().join('');
+
+    let client, chainErr;
+    let transactionStarted = false;
+    return dbConnect({
+      host: provisioningResult.postgresqlServerFullyQualifiedDomainName,
+      database: provisioningResult.postgresqldbName,
+      user: provisioningResult.administratorLogin + '@' + provisioningResult.postgresqlServerName,
+      password: provisioningResult.administratorLoginPassword,
+      ssl: true
+    })
+    .then((cl) => {
+      client = cl; // Save the client so we can close the connection later
+      return client.query('begin');
+    })
+    .then(() => {
+      transactionStarted = true;
+      // Create the user role and allow it to log in
+      let query = escape(
+        'create role %I with password %L login',
+        databaseLogin,
+        databaseLoginPassword
+      );
+      return client.query(query);
+    })
+    .then(() => {
+      // Grant the group role to the new user role
+      // (The group role has the same name as the database.)
+      let query = escape(
+        'grant %I to %I',
+        provisioningResult.postgresqldbName,
+        databaseLogin
+      );
+      return client.query(query);
+    })
+    .then(() => {
+      // Make the group role the default role for the user's session
+      let query = escape(
+        'alter role %I set role %I',
+        databaseLogin,
+        provisioningResult.postgresqldbName
+      );
+      return client.query(query);
+    })
+    .then(() => {
+      return client.query('commit');
+    })
+    .catch((err) => {
+      // There are things we want to do (like close the db connection)
+      // REGARDLESS of whether we had any errors or not, so the next .then(...)
+      // is like a "finally" of sorts, however, we want to ensure this whole
+      // chain of promises rejects with an error if one was encountered, so
+      // we'll save it here and rethrow it later if we need to.
+      chainErr = err;
+      log.error(err);
+      if (transactionStarted) return client.query('rollback');
+    })
+    .then(() => {
+      if (client) client.end();
+      if (chainErr) throw chainErr;
+      return {
+        databaseLogin: databaseLogin,
+        databaseLoginPassword: databaseLoginPassword
+      };
+    });
+  };
+
+};
+
+module.exports = postgresqldbBind;

--- a/lib/services/azurepostgresqldb/cmd-deprovision.js
+++ b/lib/services/azurepostgresqldb/cmd-deprovision.js
@@ -1,0 +1,32 @@
+/* jshint camelcase: false */
+
+'use strict';
+
+const common = require('../../common');
+const Config = require('./service');
+const log = common.getLogger(Config.name);
+const util = require('util');
+
+const postgresqldbDeprovision = function (params) {
+
+  let provisioningResult = params.provisioning_result;
+
+  log.info(
+    util.format(
+      'postgresqldb cmd-deprovision: resourceGroup: %s, postgresqldbName: %s, postgresqlServerName: %s',
+      provisioningResult.resourceGroup,
+      provisioningResult.postgresqldbName,
+      provisioningResult.postgresqlServerName
+    )
+  );
+
+  this.deprovision = function (client) {
+    return client.servers.deleteMethod(
+      provisioningResult.resourceGroup,
+      provisioningResult.postgresqlServerName
+    );
+  };
+
+};
+
+module.exports = postgresqldbDeprovision;

--- a/lib/services/azurepostgresqldb/cmd-poll.js
+++ b/lib/services/azurepostgresqldb/cmd-poll.js
@@ -1,0 +1,135 @@
+/* jshint camelcase: false */
+
+'use strict';
+
+const HttpStatus = require('http-status-codes');
+const common = require('../../common');
+const Config = require('./service');
+const log = common.getLogger(Config.name);
+const util = require('util');
+const escape = require('pg-escape');
+
+const postgresqldbPoll = function (params) {
+
+  let provisioningResult = params.provisioning_result;
+
+  log.info(
+    util.format(
+      'postgresqldb cmd-poll: resourceGroup: %s, postgresqldbName: %s, postgresqlServerName: %s',
+      provisioningResult.resourceGroup,
+      provisioningResult.postgresqldbName,
+      provisioningResult.postgresqlServerName
+    )
+  );
+
+  this.poll = function (client, dbConnect) {
+    if (params.last_operation === 'provision') {
+      let fullyQualifiedDomainName, dbClient;
+      return client.servers.get(
+        provisioningResult.resourceGroup,
+        provisioningResult.postgresqlServerName
+      )
+      .then((server) => {
+        fullyQualifiedDomainName = server.fullyQualifiedDomainName;
+        return client.databases.get(
+          provisioningResult.resourceGroup,
+          provisioningResult.postgresqlServerName,
+          provisioningResult.postgresqldbName
+        );
+      })
+      .then(() => {
+        // If we get to here, the database exists... we need to connect to it
+        // and verify that it's owned by the correct (group) role (the one
+        // with the same name as the database itself) as that will be the true
+        // indication that the provisioning process is 100% complete.
+        return dbConnect({
+          host: fullyQualifiedDomainName,
+          database: provisioningResult.postgresqldbName,
+          user: provisioningResult.administratorLogin + '@' + provisioningResult.postgresqlServerName,
+          password: provisioningResult.administratorLoginPassword,
+          ssl: true
+        });
+      })
+      .then((dbCl) => {
+        dbClient = dbCl; // Save the client so we can close the connection later
+        let query = escape(
+          'select pg_catalog.pg_get_userbyid(datdba) as owner from pg_catalog.pg_database where datname = %L',
+          provisioningResult.postgresqldbName
+        );
+        return dbClient.query(query);
+      })
+      .then((result) => {
+        // Provisioning isn't complete if the db isn't owned by a role of the
+        // same name
+        if (result.rows[0].owner !== provisioningResult.postgresqldbName) {
+          let err = new Error();
+          err.reason = 'wrong owner';
+          throw err;
+        }
+      })
+      .then(() => {
+        return {
+          state: 'succeeded',
+          description: util.format(
+            'Created database %s on server %s.',
+            provisioningResult.postgresqldbName,
+            provisioningResult.postgresqlServerName
+          ),
+          postgresqlServerFullyQualifiedDomainName: fullyQualifiedDomainName
+        };
+      })
+      .catch((err) => {
+        if (dbClient) dbClient.end();
+        if (
+          (err.statusCode !== HttpStatus.NOT_FOUND) &&
+          (err.reason !== 'wrong owner')
+        ) throw err;
+        return {
+          state: 'in progress',
+          description: util.format(
+            'Creating database %s on server %s.',
+            provisioningResult.postgresqldbName,
+            provisioningResult.postgresqlServerName
+          )
+        };
+      });
+    } else if (params.last_operation === 'deprovision') {
+      return client.servers.get(
+        provisioningResult.resourceGroup,
+        provisioningResult.postgresqlServerName
+      )
+      .then(() => {
+        return {
+          state: 'in progress',
+          description: util.format(
+            'Deleting database %s on server %s.',
+            provisioningResult.postgresqldbName,
+            provisioningResult.postgresqlServerName
+          )
+        };
+      })
+      .catch((err) => {
+        if (err.statusCode !== HttpStatus.NOT_FOUND) {
+          throw err;
+        }
+        return {
+          state: 'succeeded',
+          description: util.format(
+            'Deleted database %s on server %s.',
+            provisioningResult.postgresqldbName,
+            provisioningResult.postgresqlServerName
+          )
+        };
+      });
+    }
+    return Promise.reject(
+      new Error(util.format(
+        'Unrecognized lastoperation %s'),
+        params.last_operation
+      )
+    );
+  };
+
+};
+
+module.exports = postgresqldbPoll;

--- a/lib/services/azurepostgresqldb/cmd-provision.js
+++ b/lib/services/azurepostgresqldb/cmd-provision.js
@@ -1,0 +1,255 @@
+/* jshint camelcase: false */
+
+'use strict';
+
+const _ = require('underscore');
+const HttpStatus = require('http-status-codes');
+const common = require('../../common');
+const Config = require('./service');
+const log = common.getLogger(Config.name);
+const util = require('util');
+const escape = require('pg-escape');
+
+const postgresqldbProvision = function (params) {
+
+  let reqParams = params.parameters || {};
+
+  let resourceGroup = reqParams.resourceGroup || '';
+  let location = reqParams.location || '';
+
+  let postgresqlServerName = reqParams.postgresqlServerName || '';
+  let postgresqldbName = reqParams.postgresqldbName || '';
+
+  let administratorLogin = null, administratorLoginPassword = null;
+  if (reqParams.postgresqlServerParameters) {
+    let properties = reqParams.postgresqlServerParameters.properties;
+    if (properties) {
+      administratorLogin = properties.administratorLogin;
+      administratorLoginPassword = properties.administratorLoginPassword;
+    }
+  }
+
+  log.info(
+    util.format(
+      'postgresqldb cmd-provision: resourceGroup: %s, postgresqldbName: %s, postgresqlServerName: %s',
+      resourceGroup,
+      postgresqldbName,
+      postgresqlServerName
+    )
+  );
+
+  let firewallRules = null;
+
+  if (!_.isUndefined(reqParams.postgresqlServerParameters)) {
+    if (!_.isUndefined(reqParams.postgresqlServerParameters.allowPostgresqlServerFirewallRules)) {
+      firewallRules = reqParams.postgresqlServerParameters.allowPostgresqlServerFirewallRules;
+    }
+  }
+
+  this.validate = function (client) {
+
+    function validateFirewallRules() {
+      if (!firewallRules) return true; // no firewall rule at all is ok
+      if (!(firewallRules instanceof Array)) return false;
+      for (let i = 0; i < firewallRules.length; i++) {
+        let rule = firewallRules[i];
+        if (!rule.ruleName) return false;
+        if (!rule.startIpAddress) return false;
+        if (!_.isString(rule.startIpAddress)) return false;
+        if (rule.startIpAddress.search('^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$') !== 0) return false;
+        if (!rule.endIpAddress) return false;
+        if (!_.isString(rule.endIpAddress)) return false;
+        if (rule.endIpAddress.search('^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$') !== 0) return false;
+      }
+      return true;
+    }
+
+    function getServer(client) {
+      return client.servers.get(resourceGroup, postgresqlServerName);
+    }
+
+    let invalidParams = [];
+    let names = ['resourceGroup', 'location', 'postgresqlServerName', 'postgresqldbName', 'administratorLogin', 'administratorLoginPassword'];
+    let values = [resourceGroup, location, postgresqlServerName, postgresqldbName, administratorLogin, administratorLoginPassword];
+    for (let i = 0; i < names.length; i++) {
+      if (!_.isString(values[i]) || values[i].length === 0) {
+        invalidParams.push(names[i]);
+      }
+    }
+
+    if (!validateFirewallRules()) invalidParams.push('allowPostgresqlServerFirewallRules');
+
+    if (invalidParams.length === 0) {
+      // See if a server with this name already exists. If it does, this
+      // is a problem.
+      return getServer(client)
+      .then(() => {
+        // A server with this name already exists-- which is a problem
+        let err = new Error('The server name is unavailable');
+        err.isValidationError = true;
+        throw err;
+      })
+      .catch((err) => {
+        // If the error is a 404, we're ok, but if it's anything else, throw it
+        if (err.statusCode != HttpStatus.NOT_FOUND) {
+          throw err;
+        }
+      });
+    }
+
+    // If we get to here, there were validation errors
+    let err = new Error('Validation errors');
+    err.isValidationError = true;
+    err.invalidParams = invalidParams;
+    return Promise.reject(err);
+
+  };
+
+  this.provision = function (client, resourceClient, dbConnect, callback) {
+
+    function getResourceGroup(client) {
+      return client.resourceGroups.get(resourceGroup);
+    }
+
+    function createResourceGroup(client) {
+      return client.resourceGroups.createOrUpdate(
+        resourceGroup,
+        {
+          location: location,
+        }
+      );
+    }
+
+    function createServer(client) {
+      return client.servers.createOrUpdate(
+        resourceGroup,
+        postgresqlServerName, {
+          location: location,
+          properties: {
+            createMode: 'Default',
+            administratorLogin: administratorLogin,
+            administratorLoginPassword: administratorLoginPassword
+          }
+        }
+      );
+    }
+
+    function createFirewallRule(client, rule) {
+      return client.firewallRules.createOrUpdate(
+        resourceGroup,
+        postgresqlServerName,
+        rule.ruleName,
+        {
+          startIpAddress: rule.startIpAddress,
+          endIpAddress: rule.endIpAddress
+        }
+      );
+    }
+
+    function createDatabase(client) {
+      return client.databases.createOrUpdate(
+        resourceGroup,
+        postgresqlServerName,
+        postgresqldbName,
+        {}
+      );
+    }
+
+    let dbClient, chainErr, postgresqlServerFullyQualifiedDomainName;
+    let invokedCallback = false;
+    let dbTransactionStarted = false;
+    return getResourceGroup(resourceClient)
+    .catch((err) => {
+      if (err.statusCode == HttpStatus.NOT_FOUND) {
+        // Recover by creating the resource group
+        return createResourceGroup(resourceClient);
+      }
+      throw err;
+    })
+    .then(() => {
+      // TODO: We really shouldn't do this until the create request is accepted
+      callback(); // This should trigger a response to the waiting client
+      invokedCallback = true;
+      return createServer(client);  
+    })
+    .then(() => {
+      return client.servers.get(resourceGroup, postgresqlServerName);
+    })
+    .then((server) => {
+      postgresqlServerFullyQualifiedDomainName = server.fullyQualifiedDomainName;
+      if (firewallRules) {
+        let fps = [];
+        for (let i = 0; i < firewallRules.length; i++) {
+          fps.push(createFirewallRule(client, firewallRules[i]));
+        }
+        return Promise.all(fps);
+      }
+    })
+    .then(() => {
+      return createDatabase(client);
+    })
+    .then(() => {
+      return dbConnect({
+        host: postgresqlServerFullyQualifiedDomainName,
+        database: postgresqldbName,
+        user: administratorLogin + '@' + postgresqlServerName,
+        password: administratorLoginPassword,
+        ssl: true
+      });
+    })
+    .then((dbCl) => {
+      dbClient = dbCl; // Save the client so we can close the connection later
+      return dbClient.query('begin');
+    })
+    .then(() => {
+      dbTransactionStarted = true;
+      let query = escape('create role %I', postgresqldbName);
+      return dbClient.query(query);
+    })
+    .then(() => {
+      let query = escape(
+        'grant %I to %I',
+        postgresqldbName,
+        administratorLogin
+      );
+      return dbClient.query(query);
+    })
+    .then(() => {
+      let query = escape(
+        'alter database %I owner to %I',
+        postgresqldbName,
+        postgresqldbName
+      );
+      return dbClient.query(query);
+    })
+    .then(() => {
+      return dbClient.query('commit');
+    })
+    .catch((err) => {
+      // There are things we want to do (like close the db connection)
+      // REGARDLESS of whether we had any errors or not, so the next .then(...)
+      // is like a "finally" of sorts, however, we want to ensure this whole
+      // chain of promises rejects with an error if one was encountered, so
+      // we'll save it here and rethrow it later if we need to.
+      chainErr = err;
+      log.error(err);
+      if (dbTransactionStarted) return dbClient.query('rollback');
+    })
+    .then(() => {
+      if (dbClient) dbClient.end();
+      // If there are any errors, return them instead of throwing them.
+      // We've already responded to the client by now (see callback call
+      // above), so any error that occurs at this point shouldn't cause the
+      // whole chain to be rejected or else we'll be responding a second
+      // time and that will cause an error.
+      if (chainErr) {
+        if (invokedCallback) return chainErr;
+        throw chainErr;
+      }
+    });
+
+  };
+
+};
+
+module.exports = postgresqldbProvision;

--- a/lib/services/azurepostgresqldb/cmd-provision.js
+++ b/lib/services/azurepostgresqldb/cmd-provision.js
@@ -9,6 +9,8 @@ const Config = require('./service');
 const log = common.getLogger(Config.name);
 const util = require('util');
 const escape = require('pg-escape');
+const pgUtils = require('./pg-utils');
+var uuid = require('uuid');
 
 const postgresqldbProvision = function (params) {
 
@@ -17,8 +19,10 @@ const postgresqldbProvision = function (params) {
   let resourceGroup = reqParams.resourceGroup || '';
   let location = reqParams.location || '';
 
-  let postgresqlServerName = reqParams.postgresqlServerName || '';
-  let postgresqldbName = reqParams.postgresqldbName || '';
+  let postgresqlServerName = reqParams.postgresqlServerName || uuid.v4();
+
+  let postgresqldbName = reqParams.postgresqldbName ||
+      pgUtils.generateIdentifier();
 
   let administratorLogin = null, administratorLoginPassword = null;
   if (reqParams.postgresqlServerParameters) {
@@ -28,6 +32,8 @@ const postgresqldbProvision = function (params) {
       administratorLoginPassword = properties.administratorLoginPassword;
     }
   }
+  administratorLogin = administratorLogin || pgUtils.generateIdentifier();
+  administratorLoginPassword = administratorLoginPassword || pgUtils.generatePassword();
 
   log.info(
     util.format(
@@ -39,17 +45,18 @@ const postgresqldbProvision = function (params) {
   );
 
   let firewallRules = null;
-
-  if (!_.isUndefined(reqParams.postgresqlServerParameters)) {
-    if (!_.isUndefined(reqParams.postgresqlServerParameters.allowPostgresqlServerFirewallRules)) {
-      firewallRules = reqParams.postgresqlServerParameters.allowPostgresqlServerFirewallRules;
-    }
+  if (reqParams.postgresqlServerParameters) {
+    firewallRules = reqParams.postgresqlServerParameters.allowPostgresqlServerFirewallRules;
   }
+  firewallRules = firewallRules || [{
+    ruleName: 'AllowAllIps',
+    startIpAddress: '0.0.0.0',
+    endIpAddress: '255.255.255.255'
+  }];
 
   this.validate = function (client) {
 
     function validateFirewallRules() {
-      if (!firewallRules) return true; // no firewall rule at all is ok
       if (!(firewallRules instanceof Array)) return false;
       for (let i = 0; i < firewallRules.length; i++) {
         let rule = firewallRules[i];
@@ -69,8 +76,8 @@ const postgresqldbProvision = function (params) {
     }
 
     let invalidParams = [];
-    let names = ['resourceGroup', 'location', 'postgresqlServerName', 'postgresqldbName', 'administratorLogin', 'administratorLoginPassword'];
-    let values = [resourceGroup, location, postgresqlServerName, postgresqldbName, administratorLogin, administratorLoginPassword];
+    let names = ['resourceGroup', 'location'];
+    let values = [resourceGroup, location];
     for (let i = 0; i < names.length; i++) {
       if (!_.isString(values[i]) || values[i].length === 0) {
         invalidParams.push(names[i]);
@@ -168,7 +175,13 @@ const postgresqldbProvision = function (params) {
     })
     .then(() => {
       // TODO: We really shouldn't do this until the create request is accepted
-      callback(); // This should trigger a response to the waiting client
+      callback({ // This should trigger a response to the waiting client
+        resourceGroup: resourceGroup,
+        postgresqlServerName: postgresqlServerName,
+        postgresqldbName: postgresqldbName,
+        administratorLogin: administratorLogin,
+        administratorLoginPassword: administratorLoginPassword
+      });
       invokedCallback = true;
       return createServer(client);  
     })

--- a/lib/services/azurepostgresqldb/cmd-unbind.js
+++ b/lib/services/azurepostgresqldb/cmd-unbind.js
@@ -1,0 +1,57 @@
+/* jshint camelcase: false */
+
+'use strict';
+
+const common = require('../../common');
+const Config = require('./service');
+const log = common.getLogger(Config.name);
+const util = require('util');
+const escape = require('pg-escape');
+
+const postgresqlUnbind = function (params) {
+
+  let provisioningResult = params.provisioning_result;
+  let bindingResult = params.binding_result;
+
+  log.info(
+    util.format(
+      'postgresql cmd-unbind: resourceGroup: %s, postgresqldbName: %s, postgresqlServerName: %s',
+      provisioningResult.resourceGroup,
+      provisioningResult.postgresqldbName,
+      provisioningResult.postgresqlServerName
+    )
+  );
+
+  this.unbind = function (dbConnect) {
+    let client, chainErr;
+    // Use a factory method to get the db connection
+    return dbConnect({
+      host: provisioningResult.postgresqlServerFullyQualifiedDomainName,
+      database: provisioningResult.postgresqldbName,
+      user: provisioningResult.administratorLogin + '@' + provisioningResult.postgresqlServerName,
+      password: provisioningResult.administratorLoginPassword,
+      ssl: true
+    })
+    .then((cl) => {
+      client = cl; // Save the client so we can close the connection later
+      let query = escape('drop role %I', bindingResult.databaseLogin);
+      return client.query(query);
+    })
+    .catch((err) => {
+      // There are things we want to do (like close the db connection)
+      // REGARDLESS of whether we had any errors or not, so the next .then(...)
+      // is like a "finally" of sorts, however, we want to ensure this whole
+      // chain of promises rejects with an error if one was encountered, so
+      // we'll save it here and rethrow it later if we need to.
+      chainErr = err;
+      log.error(err);
+    })
+    .then(() => {
+      if (client) client.end();
+      if (chainErr) throw chainErr;
+    });
+  };
+
+};
+
+module.exports = postgresqlUnbind;

--- a/lib/services/azurepostgresqldb/index.js
+++ b/lib/services/azurepostgresqldb/index.js
@@ -1,0 +1,261 @@
+/* jshint camelcase: false */
+
+'use strict';
+
+const util = require('util');
+const msRestAzure = require('ms-rest-azure');
+const HttpStatus = require('http-status-codes');
+const Config = require('./service');
+const common = require('../../common/');
+const log = common.getLogger(Config.name);
+const CmdProvision = require('./cmd-provision');
+const CmdPoll = require('./cmd-poll');
+const CmdDeprovision = require('./cmd-deprovision');
+const CmdBind = require('./cmd-bind');
+const CmdUnbind = require('./cmd-unbind');
+const PostgreSQLManagementClient = require('azure-arm-postgresql');
+const ResourceManagementClient = require('azure-arm-resource').ResourceManagementClient;
+const pg = require('pg');
+
+const Handlers = {};
+
+function login(params) {
+  return msRestAzure.loginWithServicePrincipalSecret(
+    params.azure.clientId,
+    params.azure.clientSecret,
+    params.azure.tenantId
+  );
+}
+
+function dbConnect(config) {
+  return new Promise((resolve, reject) => {
+    let client = new pg.Client(config);
+    client.connect(function (err) {
+      if (err) {
+        reject(err);
+      } else {
+        // Workaround: Mainly during testing, encountering many cases of
+        // connection reset by peer. We'll log and eat errors from IDLE
+        // connections. This should be a harmless thing to do. The broker
+        // doesn't interact with any given Postgres database with any real
+        // frequency, so we use no connection pooling. i.e. Every connection
+        // is intended to standalone and be discarded after a single use
+        // anyway. Note that this will not eat errors caused by a query.
+        // Those will still be handled by the catch in the promise chain.
+        client.on('error', function(err) {
+          log.warn(err);
+        });
+        resolve(client);
+      }
+    });
+  });
+}
+
+Handlers.catalog = function (params, next) {
+  next(null, Config);
+};
+
+Handlers.generateAzureInstanceId = function(params) {
+  return Config.name + '-' + params.parameters.postgresqlServerName + '-' + params.parameters.postgresqldbName;
+};
+
+Handlers.provision = function (params, next) {
+  log.debug('PostgreSqlDB/index/provision/params: %j', params);
+
+  let cp = new CmdProvision(params);
+  let pmc;
+  let rmc;
+  login(params)
+  .then((credentials) => {
+    let endpointUrl = common.getEnvironment(
+      params.azure.environment
+    ).resourceManagerEndpointUrl;
+    pmc = new PostgreSQLManagementClient(
+      credentials,
+      params.azure.subscriptionId,
+      endpointUrl
+    );
+    rmc = new ResourceManagementClient(
+      credentials,
+      params.azure.subscriptionId,
+      endpointUrl
+    );
+    return cp.validate(pmc);
+  })
+  .then(() => {
+    return cp.provision(pmc, rmc, dbConnect, function() {
+      let reqParams = params.parameters;
+      next(
+        null,
+        {
+          statusCode: HttpStatus.ACCEPTED,
+          code: HttpStatus.getStatusText(HttpStatus.ACCEPTED),
+          value: {},
+        },
+        {
+          resourceGroup: reqParams.resourceGroup,
+          postgresqlServerName: reqParams.postgresqlServerName,
+          postgresqldbName: reqParams.postgresqldbName,
+          administratorLogin: reqParams.postgresqlServerParameters.properties.administratorLogin,
+          administratorLoginPassword: reqParams.postgresqlServerParameters.properties.administratorLoginPassword
+        }
+      );
+    });
+  })
+  .catch((err) => {
+    if (err.isValidationError) {
+      if (err.invalidParams) {
+        common.handleServiceErrorEx(
+          HttpStatus.BAD_REQUEST,
+          util.format(
+            'Parameter validation failed. Please check your parameters: %s',
+            err.invalidParams.join(', ')
+          ),
+          next
+        );
+      } else {
+        common.handleServiceErrorEx(
+          HttpStatus.BAD_REQUEST,
+          err.message,
+          next
+        );
+      }
+    } else {
+      common.handleServiceErrorEx(err, next);
+    }
+  });
+
+};
+
+Handlers.poll = function (params, next) {
+  log.debug('PostgreSqlDb/index/poll/params: %j', params);
+
+  let lastOperation = params.last_operation;
+
+  login(params)
+  .then((credentials) => {
+    let pmc = new PostgreSQLManagementClient(
+      credentials,
+      params.azure.subscriptionId,
+      common.getEnvironment(params.azure.environment).resourceManagerEndpointUrl
+    );
+    let cp = new CmdPoll(params);
+    return cp.poll(pmc, dbConnect);
+  })
+  .then((reply) => {
+    params.provisioning_result.postgresqlServerFullyQualifiedDomainName = reply.postgresqlServerFullyQualifiedDomainName;
+    delete reply.postgresqlServerFullyQualifiedDomainName;
+    next(
+      null,
+      lastOperation,
+      { 
+        statusCode: HttpStatus.OK,
+        code: HttpStatus.getStatusText(HttpStatus.OK),
+        value: reply
+      },
+      params.provisioning_result
+    );
+  })
+  .catch((err) => {
+    common.handleServiceError(err, next);
+  });
+};
+
+Handlers.deprovision = function (params, next) {
+  log.debug('PostgreSqlDb/index/deprovision/params: %j', params);
+
+  login(params)
+  .then((credentials) => {
+    let pmc = new PostgreSQLManagementClient(
+      credentials,
+      params.azure.subscriptionId,
+      common.getEnvironment(params.azure.environment).resourceManagerEndpointUrl
+    );
+    let cd = new CmdDeprovision(params);
+    return cd.deprovision(pmc);
+  })
+  .then(() => {
+    next(
+      null,
+      {
+        statusCode: HttpStatus.ACCEPTED,
+        code: HttpStatus.getStatusText(HttpStatus.ACCEPTED),
+        value: {}
+      },
+      null
+    );
+  })
+  .catch((err) => {
+    common.handleServiceError(err, next);
+  });
+};
+
+Handlers.bind = function (params, next) {
+  log.debug('PostgreSqlDb/index/bind/params: %j', params);
+
+  let cb = new CmdBind(params);
+  return cb.bind(dbConnect)
+  .then((reply) => {
+    let provisioningResult = params.provisioning_result;
+    // Spring Cloud Connector Support
+    let jdbcUrlTemplate = 'jdbc:postgresql://%s:5432' +
+                          '/%s' +
+                          '?user=%s@%s' +
+                          '&password=%s' +
+                          '&ssl=true';
+    let jdbcUrl = util.format(
+      jdbcUrlTemplate,
+      provisioningResult.postgresqlServerFullyQualifiedDomainName,
+      provisioningResult.postgresqldbName,
+      reply.databaseLogin,
+      provisioningResult.postgresqlServerName,
+      reply.databaseLoginPassword
+    );
+    next(
+      null,
+      {
+        statusCode: HttpStatus.CREATED,
+        code: HttpStatus.getStatusText(HttpStatus.CREATED),
+        value: {
+          credentials: {
+            postgresqlServerName: provisioningResult.postgresqlServerName,
+            postgresqlServerFullyQualifiedDomainName: provisioningResult.postgresqlServerFullyQualifiedDomainName,
+            postgresqldbName: provisioningResult.postgresqldbName,
+            databaseLogin: reply.databaseLogin,
+            databaseLoginPassword: reply.databaseLoginPassword,
+            jdbcUrl: jdbcUrl
+          }
+        }
+      },
+      {
+        databaseLogin: reply.databaseLogin
+      }
+    );
+  })
+  .catch((err) => {
+    common.handleServiceError(err, next);
+  });
+};
+
+Handlers.unbind = function (params, next) {
+  log.debug('PostgreSqlDb/index/unbind/params: %j', params);
+
+  let cu = new CmdUnbind(params);
+  return cu.unbind(dbConnect)
+  .then(() => {
+    next(
+      null,
+      {
+        statusCode: HttpStatus.OK,
+        code: HttpStatus.getStatusText(HttpStatus.OK),
+        value: {},
+      },
+      null
+    );
+  })
+  .catch((err) => {
+    common.handleServiceError(err, next);
+  });
+};
+
+module.exports = Handlers;

--- a/lib/services/azurepostgresqldb/index.js
+++ b/lib/services/azurepostgresqldb/index.js
@@ -15,7 +15,7 @@ const CmdBind = require('./cmd-bind');
 const CmdUnbind = require('./cmd-unbind');
 const PostgreSQLManagementClient = require('azure-arm-postgresql');
 const ResourceManagementClient = require('azure-arm-resource').ResourceManagementClient;
-const pg = require('pg');
+const pgUtils = require('./pg-utils');
 
 const Handlers = {};
 
@@ -25,30 +25,6 @@ function login(params) {
     params.azure.clientSecret,
     params.azure.tenantId
   );
-}
-
-function dbConnect(config) {
-  return new Promise((resolve, reject) => {
-    let client = new pg.Client(config);
-    client.connect(function (err) {
-      if (err) {
-        reject(err);
-      } else {
-        // Workaround: Mainly during testing, encountering many cases of
-        // connection reset by peer. We'll log and eat errors from IDLE
-        // connections. This should be a harmless thing to do. The broker
-        // doesn't interact with any given Postgres database with any real
-        // frequency, so we use no connection pooling. i.e. Every connection
-        // is intended to standalone and be discarded after a single use
-        // anyway. Note that this will not eat errors caused by a query.
-        // Those will still be handled by the catch in the promise chain.
-        client.on('error', function(err) {
-          log.warn(err);
-        });
-        resolve(client);
-      }
-    });
-  });
 }
 
 Handlers.catalog = function (params, next) {
@@ -83,8 +59,7 @@ Handlers.provision = function (params, next) {
     return cp.validate(pmc);
   })
   .then(() => {
-    return cp.provision(pmc, rmc, dbConnect, function() {
-      let reqParams = params.parameters;
+    return cp.provision(pmc, rmc, pgUtils.connect, function(provisioningResult) {
       next(
         null,
         {
@@ -92,13 +67,7 @@ Handlers.provision = function (params, next) {
           code: HttpStatus.getStatusText(HttpStatus.ACCEPTED),
           value: {},
         },
-        {
-          resourceGroup: reqParams.resourceGroup,
-          postgresqlServerName: reqParams.postgresqlServerName,
-          postgresqldbName: reqParams.postgresqldbName,
-          administratorLogin: reqParams.postgresqlServerParameters.properties.administratorLogin,
-          administratorLoginPassword: reqParams.postgresqlServerParameters.properties.administratorLoginPassword
-        }
+        provisioningResult
       );
     });
   })
@@ -140,7 +109,7 @@ Handlers.poll = function (params, next) {
       common.getEnvironment(params.azure.environment).resourceManagerEndpointUrl
     );
     let cp = new CmdPoll(params);
-    return cp.poll(pmc, dbConnect);
+    return cp.poll(pmc, pgUtils.connect);
   })
   .then((reply) => {
     params.provisioning_result.postgresqlServerFullyQualifiedDomainName = reply.postgresqlServerFullyQualifiedDomainName;
@@ -194,7 +163,7 @@ Handlers.bind = function (params, next) {
   log.debug('PostgreSqlDb/index/bind/params: %j', params);
 
   let cb = new CmdBind(params);
-  return cb.bind(dbConnect)
+  return cb.bind(pgUtils.connect)
   .then((reply) => {
     let provisioningResult = params.provisioning_result;
     // Spring Cloud Connector Support
@@ -241,7 +210,7 @@ Handlers.unbind = function (params, next) {
   log.debug('PostgreSqlDb/index/unbind/params: %j', params);
 
   let cu = new CmdUnbind(params);
-  return cu.unbind(dbConnect)
+  return cu.unbind(pgUtils.connect)
   .then(() => {
     next(
       null,

--- a/lib/services/azurepostgresqldb/pg-utils.js
+++ b/lib/services/azurepostgresqldb/pg-utils.js
@@ -1,0 +1,50 @@
+'use strict';
+
+const _ = require('underscore');
+const Config = require('./service');
+const common = require('../../common/');
+const log = common.getLogger(Config.name);
+const pg = require('pg');
+
+const uppercaseLetters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
+const lowercaseLetters = uppercaseLetters.toLowerCase();
+const numbers = '1234567890';
+
+const roleLength = 10;
+const passwordLength = 16;
+
+module.exports.generateIdentifier = function() {
+  return _.sample(lowercaseLetters) +
+         _.sample(lowercaseLetters + numbers, roleLength - 1).join('');
+};
+
+module.exports.generatePassword = function() {
+  return _.sample(
+    lowercaseLetters + uppercaseLetters + numbers,
+    passwordLength
+  ).join('');
+};
+
+module.exports.connect = function(config) {
+  return new Promise((resolve, reject) => {
+    let client = new pg.Client(config);
+    client.connect(function (err) {
+      if (err) {
+        reject(err);
+      } else {
+        // Workaround: Mainly during testing, encountering many cases of
+        // connection reset by peer. We'll log and eat errors from IDLE
+        // connections. This should be a harmless thing to do. The broker
+        // doesn't interact with any given Postgres database with any real
+        // frequency, so we use no connection pooling. i.e. Every connection
+        // is intended to standalone and be discarded after a single use
+        // anyway. Note that this will not eat errors caused by a query.
+        // Those will still be handled by the catch in the promise chain.
+        client.on('error', function(err) {
+          log.warn(err);
+        });
+        resolve(client);
+      }
+    });
+  });
+};

--- a/lib/services/azurepostgresqldb/service.json
+++ b/lib/services/azurepostgresqldb/service.json
@@ -1,0 +1,97 @@
+{
+  "id": "9569986f-c4d2-47e1-ba65-6763f08c3124",
+  "name": "azure-postgresqldb",
+  "description": "Azure Database for PostgreSQL Service",
+  "bindable": true,
+  "tags": [
+    "Azure",
+    "PostgreSQL",
+    "Database"
+  ],
+  "metadata": {
+    "displayName": "Azure Database for PostgreSQL Service",
+    "imageUrl": "https://cloudfoundry.blob.core.windows.net/assets/SQLDatabase.png",
+    "longDescription": "Azure Database for PostgreSQL is a relational database service based on the open source Postgres database engine. It is a fully managed database as a service offering capable of handling mission-critical workloads with predictable performance, security, high availability, and dynamic scalability.  Develop applications with Azure Database for PostgreSQL leveraging the open source tools and platform of your choice.",
+    "providerDisplayName": "Microsoft"
+  },
+  "plans": [
+    {
+      "id": "bb6ddfd0-4d8f-4496-aa33-d64ad9562c1f",
+      "name": "basic50",
+      "free": false,
+      "description": "Basic Tier, 50 DTUs. See preview pricing here: https://azure.microsoft.com/en-us/pricing/details/mysql. We'll update it after GA.",
+      "metadata": {
+        "displayName": "Basic50",
+        "details": {
+          "tier": "Basic",
+          "capacity": 50
+        }
+      }
+    },
+    {
+      "id": "ffc1e3c8-0e24-471d-8683-1b42e100bb14",
+      "name": "basic100",
+      "free": false,
+      "description": "Basic Tier, 100 DTUs",
+      "metadata": {
+        "displayName": "Basic100",
+        "details": {
+          "tier": "Basic",
+          "capacity": 100
+        }
+      }
+    },
+    {
+      "id": "1464a2cd-ad32-4f6b-ba80-9d052e4a0fe3",
+      "name": "standard100",
+      "free": false,
+      "description": "Standard Tier, 100 DTUs",
+      "metadata": {
+        "displayName": "Standard100",
+        "details": {
+          "tier": "Standard",
+          "capacity": 100
+        }
+      }
+    },
+    {
+      "id": "83c03465-9b1d-408d-ad13-78bc4b205295",
+      "name": "standard200",
+      "free": false,
+      "description": "Standard Tier, 200 DTUs",
+      "metadata": {
+        "displayName": "Standard200",
+        "details": {
+          "tier": "Standard",
+          "capacity": 200
+        }
+      }
+    },
+    {
+      "id": "ef31f27f-c71b-4193-a0f5-61dd1a8be129",
+      "name": "standard400",
+      "free": false,
+      "description": "Standard Tier, 400 DTUs",
+      "metadata": {
+        "displayName": "Standard400",
+        "details": {
+          "tier": "Standard",
+          "capacity": 400
+        }
+      }
+    },
+    {
+      "id": "316b0d63-856e-4d34-b5b1-d7c6f83f74f9",
+      "name": "standard800",
+      "free": false,
+      "description": "Standard Tier, 800 DTUs",
+      "metadata": {
+        "displayName": "Standard800",
+        "details": {
+          "tier": "Standard",
+          "capacity": 800
+        }
+      }
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -26,17 +26,21 @@
   "license": "Apache-2.0",
   "dependencies": {
     "async": "1.5.2",
+    "azure-arm-postgresql": "file:///Users/kent/Code/azure-sdk-for-node/lib/services/postgresqlManagement",
+    "azure-arm-resource": "2.0.0-preview",
     "config": "1.21.0",
     "http-status-codes": "1.0.6",
-    "winston": "2.3.1",
-    "ms-rest-azure": "1.14.5",
+    "ms-rest-azure": "2.1.2",
     "mssql": "3.1.2",
+    "pg": "^6.2.3",
+    "pg-escape": "^0.2.0",
     "request": "2.72.0",
     "restify": "4.3.0",
     "semver": "5.1.0",
     "string": "3.3.1",
     "underscore": "1.8.3",
-    "uuid": "3.0.1"
+    "uuid": "3.0.1",
+    "winston": "2.3.1"
   },
   "devDependencies": {
     "azure": "0.10.6",
@@ -49,7 +53,8 @@
     "mocha": "3.3.0",
     "redis": "2.6.1",
     "should": "11.2.1",
-    "sinon": "1.17.3",
+    "should-sinon": "0.0.5",
+    "sinon": "^2.3.4",
     "tedious": "^1.14.0",
     "documentdb": "1.6.0",
     "mock-require": "2.0.1"

--- a/test/integration/submatrix/postgresqldb.js
+++ b/test/integration/submatrix/postgresqldb.js
@@ -1,0 +1,63 @@
+const uuid = require('uuid');
+const util = require('util');
+const _ = require('underscore');
+
+const supportedEnvironments = require('../../utils/supportedEnvironments');
+
+let testMatrix = [];
+
+var environment = process.env['ENVIRONMENT'];
+if (!_.has(supportedEnvironments, environment)) {
+  throw new Error(util.format('The test does not support %s', environment));
+}
+
+var location = supportedEnvironments[environment]['location'];
+
+let instanceId = uuid.v4();
+let bindingId = uuid.v4();
+let resourceGroup = 'cloud-foundry-' + instanceId;
+let postgresqlServerName = 'cf' + instanceId;
+let postgresqldbName = 'my_db';
+let postgresqldb = {
+  serviceName: 'azure-postgresqldb',
+  serviceId: '9569986f-c4d2-47e1-ba65-6763f08c3124',
+  planId: 'bb6ddfd0-4d8f-4496-aa33-d64ad9562c1f',
+  instanceId: instanceId,
+  bindingId: bindingId,
+  provisioningParameters: {
+    resourceGroup: resourceGroup,
+    location: location,
+    postgresqlServerName: postgresqlServerName,
+    postgresqlServerParameters: {
+      allowPostgresqlServerFirewallRules: [
+        {
+          ruleName: 'AllowAllIps',
+          startIpAddress: '0.0.0.0',
+          endIpAddress: '255.255.255.255'
+        }
+      ],
+      properties: {
+        // sslEnforcement: 'Disabled',
+        administratorLogin: 'azureuser',
+        administratorLoginPassword: 'c1oudc0w!@#'
+      },
+      tags: {
+        foo: 'bar'
+      }
+    },
+    postgresqldbName: postgresqldbName
+  },
+  bindingParameters: {},
+  credentials: {
+    databaseLogin: '<string>',
+    databaseLoginPassword: '<string>',
+    postgresqlServerName: postgresqlServerName,
+    postgresqlServerFullyQualifiedDomainName: '<string>',
+    postgresqldbName: postgresqldbName,
+    jdbcUrl: '<string>'
+  },
+  e2e: true
+};
+testMatrix.push(postgresqldb);
+
+module.exports = testMatrix;

--- a/test/integration/submatrix/postgresqldb.js
+++ b/test/integration/submatrix/postgresqldb.js
@@ -16,8 +16,6 @@ var location = supportedEnvironments[environment]['location'];
 let instanceId = uuid.v4();
 let bindingId = uuid.v4();
 let resourceGroup = 'cloud-foundry-' + instanceId;
-let postgresqlServerName = 'cf' + instanceId;
-let postgresqldbName = 'my_db';
 let postgresqldb = {
   serviceName: 'azure-postgresqldb',
   serviceId: '9569986f-c4d2-47e1-ba65-6763f08c3124',
@@ -27,33 +25,44 @@ let postgresqldb = {
   provisioningParameters: {
     resourceGroup: resourceGroup,
     location: location,
-    postgresqlServerName: postgresqlServerName,
+    // // The postgresqlServerName is deliberately withheld to verify is is
+    // // sensibly defaulted. The following line shows how it COULD be
+    // // specified.
+    // postgresqlServerName: 'cf' + instanceId,
     postgresqlServerParameters: {
-      allowPostgresqlServerFirewallRules: [
-        {
-          ruleName: 'AllowAllIps',
-          startIpAddress: '0.0.0.0',
-          endIpAddress: '255.255.255.255'
-        }
-      ],
-      properties: {
-        // sslEnforcement: 'Disabled',
-        administratorLogin: 'azureuser',
-        administratorLoginPassword: 'c1oudc0w!@#'
-      },
+      // // These firewall rules are deliberately withheld to verify they are
+      // // sensibly defaulted. The following lines show how they COULD be
+      // // specified.
+      // allowPostgresqlServerFirewallRules: [
+      //   {
+      //     ruleName: 'AllowAllIps',
+      //     startIpAddress: '0.0.0.0',
+      //     endIpAddress: '255.255.255.255'
+      //   }
+      // ],
+      // // These properties are deliberately withheld to verify they are
+      // // sensibly defaulted to random values. The following lines show how
+      // // they COULD be specified.
+      // properties: {
+      //   administratorLogin: 'azureuser',
+      //   administratorLoginPassword: 'c1oudc0w!@#'
+      // },
       tags: {
         foo: 'bar'
       }
     },
-    postgresqldbName: postgresqldbName
+    // // The postgresqldbName is deliberately withheld to verify it is
+    // // sensibly defaulted. The following line shows how it COULD be
+    // // specified.
+    // postgresqldbName: 'my_db'
   },
   bindingParameters: {},
   credentials: {
     databaseLogin: '<string>',
     databaseLoginPassword: '<string>',
-    postgresqlServerName: postgresqlServerName,
+    postgresqlServerName: '<string>',
     postgresqlServerFullyQualifiedDomainName: '<string>',
-    postgresqldbName: postgresqldbName,
+    postgresqldbName: '<string>',
     jdbcUrl: '<string>'
   },
   e2e: true

--- a/test/integration/test-matrix.js
+++ b/test/integration/test-matrix.js
@@ -1,4 +1,11 @@
-var submatrix = ['storage', 'servicebus', 'docdb', 'sqldb', 'rediscache'];
+var submatrix = [
+    'storage',
+    'servicebus',
+    'docdb',
+    'sqldb',
+    'rediscache',
+    'postgresqldb'
+];
 
 var testMatrix = [];
 

--- a/test/unit/services/azurepostgresqldb/bind-spec.js
+++ b/test/unit/services/azurepostgresqldb/bind-spec.js
@@ -1,0 +1,96 @@
+/* jshint camelcase: false */
+
+'use strict';
+
+const sinon = require('sinon');
+require('should');
+require('should-sinon');
+
+const CmdBind = require('../../../../lib/services/azurepostgresqldb/cmd-bind');
+
+describe('PostgreSqlDb - bind command', function() {
+
+  let params;
+  let dbc; // database connection factory function
+  let pc; // postgresql client
+  let cb;
+
+  beforeEach(function() {
+    params = {
+      provisioning_result: {
+        resourceGroup: 'fake-resource-group-name',
+        postgresqlServerName: 'fake-server-name',
+        postgresqldbName: 'fake-db-name'
+      }
+    };
+
+    pc = {};
+    pc.query = sinon.stub();
+    pc.end = sinon.stub();
+    // Resolve query with a fake result
+    pc.query.resolves({});
+
+    dbc = sinon.stub();
+    // Factory function resolves to a fake postgres client
+    dbc.resolves(pc);
+    
+    cb = new CmdBind(params);
+  });
+
+  it('should bind', function() {
+    return cb.bind(dbc).should.be.fulfilled()
+    .then(() => {
+      dbc.should.be.calledOnce();
+      pc.query.should.have.callCount(5);
+      pc.end.should.be.calledOnce();
+    });
+  });
+
+  describe('error connecting to the database', function() {
+
+    beforeEach(function() {
+      // Rejects with an unspecified error
+      dbc.rejects(new Error());
+    });
+
+    it('should not bind', function() {
+      return cb.bind(dbc).should.be.rejected()
+      .then(() => {
+        dbc.should.be.calledOnce();
+        pc.query.should.not.be.called();
+        pc.end.should.not.be.called();
+      });
+    });
+
+  });
+
+  describe('unspecified error', function() {
+
+    beforeEach(function() {
+      // The first call starts the transaction
+      pc.query.onCall(0).resolves({});
+      // The second call errors
+      pc.query.onCall(1).rejects(new Error());
+      // The third call rolls the transaction back
+      pc.query.onCall(2).resolves({});
+    });
+
+    it('should not bind', function() {
+      return cb.bind(dbc).should.be.rejected()
+      .then(() => {
+        dbc.should.be.calledOnce();
+        // query function should be called x 3:
+        // 0. Start the transaction
+        // 1. Bad query
+        // 2. Rollback
+        pc.query.should.be.calledThrice();
+        pc.query.should.be.calledWith('begin');
+        pc.query.should.not.be.calledWith('commit');
+        pc.query.should.be.calledWith('rollback');
+        pc.end.should.be.calledOnce();
+      });
+    });
+
+  });
+
+});

--- a/test/unit/services/azurepostgresqldb/deprovision-spec.js
+++ b/test/unit/services/azurepostgresqldb/deprovision-spec.js
@@ -1,0 +1,44 @@
+/* jshint camelcase: false */
+
+'use strict';
+
+const sinon = require('sinon');
+require('should');
+require('should-sinon');
+
+const CmdDeprovision = require('../../../../lib/services/azurepostgresqldb/cmd-deprovision');
+
+describe('PostgreSqlDb - deprovision command', function() {
+
+  let params;
+  let pmc; // postgresql management client
+  let cd;
+
+  beforeEach(function() {
+    params = {
+      provisioning_result: {
+        resourceGroup: 'fake-resource-group-name',
+        postgresqlServerName: 'fake-server-name',
+        postgresqldbName: 'fake-db-name'
+      }
+    };
+    pmc = {
+      servers: {}
+    };
+    pmc.servers.deleteMethod = sinon.stub();
+    cd = new CmdDeprovision(params);
+  });
+
+  beforeEach(function() {
+    // Resolve
+    pmc.servers.deleteMethod.resolves();
+  });
+
+  it('should deprovision', function() {
+    return cd.deprovision(pmc).should.be.fulfilled()
+    .then(() => {
+      pmc.servers.deleteMethod.should.be.calledOnce();
+    });
+  });
+
+});

--- a/test/unit/services/azurepostgresqldb/poll-spec.js
+++ b/test/unit/services/azurepostgresqldb/poll-spec.js
@@ -1,0 +1,234 @@
+/* jshint camelcase: false */
+
+'use strict';
+
+const sinon = require('sinon');
+require('should');
+require('should-sinon');
+
+const HttpStatus = require('http-status-codes');
+
+const CmdPoll = require('../../../../lib/services/azurepostgresqldb/cmd-poll');
+
+describe('PostgreSqlDb - poll command', function() {
+
+  let params;
+  let pmc; // postgresql management client
+  let dbc; // database connection factory function
+  let pc; // postgresql client
+  let cp;
+
+  const errNotFound = new Error();
+
+  before(function() {
+    errNotFound.statusCode = HttpStatus.NOT_FOUND;
+  });
+
+  beforeEach(function() {
+    params = {
+      provisioning_result: {
+        resourceGroup: 'fake-resource-group-name',
+        postgresqlServerName: 'fake-server-name',
+        postgresqldbName: 'fake-db-name'
+      }
+    };
+
+    pmc = {
+      servers: {},
+      databases: {}
+    };
+    pmc.servers.get = sinon.stub();
+    pmc.databases.get = sinon.stub();
+
+    pc = {};
+    pc.query = sinon.stub();
+    pc.end = sinon.stub();
+
+    dbc = sinon.stub();
+    // Factory function resolves to a fake postgres client
+    dbc.resolves(pc);
+  });
+
+  describe('polling provisioning status', function() {
+
+    beforeEach(function() {
+      params.last_operation = 'provision';
+      cp = new CmdPoll(params);
+      // Resolve query with a fake (good) result
+      pc.query.resolves({
+        rows: [ { owner: 'fake-db-name' } ]
+      });
+    });
+
+    describe('an unspecified error occurs retrieving server', function() {
+
+      beforeEach(function() {
+        // Reject with an unspecified error
+        pmc.servers.get.rejects(new Error());
+      });
+
+      it('should fail', function() {
+        return cp.poll(pmc, dbc).should.be.rejected();
+      });
+
+    });
+
+    describe('server does not exist', function() {
+
+      beforeEach(function() {
+        // Reject with a 404
+        pmc.servers.get.rejects(errNotFound);
+      });
+
+      it('should determine provisioning is in progress', function() {
+        return cp.poll(pmc, dbc).should.be.fulfilled().then((reply) => {
+          reply.state.should.equal('in progress');
+          reply.description.should.containEql('Creating database');
+        });
+      });
+
+    });
+
+    describe('server exists', function() {
+
+      beforeEach(function() {
+        // Resolve with a fake server
+        pmc.servers.get.resolves({});
+      });
+
+      describe('an unspecified error occurs retrieving database', function() {
+
+        beforeEach(function() {
+          // Reject with an unspecified error
+          pmc.databases.get.rejects(new Error());
+        });
+
+        it('should fail', function() {
+          return cp.poll(pmc, dbc).should.be.rejected();
+        });
+
+      });
+
+      describe('database does not exist', function() {
+
+        beforeEach(function() {
+          // Reject with a 404
+          pmc.databases.get.rejects(errNotFound);
+        });
+
+        it('should determine provisioning is in progress', function() {
+          return cp.poll(pmc, dbc).should.be.fulfilled().then((reply) => {
+            reply.state.should.equal('in progress');
+            reply.description.should.containEql('Creating database');
+          });
+        });
+
+      });
+
+      describe('database exists', function() {
+
+        beforeEach(function() {
+          // Resolve with a fake database
+          pmc.databases.get.resolves({});
+        });
+
+        describe('database has wrong owner', function() {
+
+          beforeEach(function() {
+            // Resolve query with a fake (bad) result
+            pc.query.resolves({
+              rows: [ { owner: 'azureuser' } ]
+            });
+          });
+
+          it('should determine provisioning is in progress', function() {
+            return cp.poll(pmc, dbc).should.be.fulfilled().then((reply) => {
+              reply.state.should.equal('in progress');
+              reply.description.should.containEql('Creating database');
+              pc.query.should.be.calledOnce();
+            });
+          });
+
+        });
+
+        it('should determine provisioning succeeded', function() {
+          return cp.poll(pmc, dbc).should.be.fulfilled().then((reply) => {
+            reply.state.should.equal('succeeded');
+            reply.description.should.containEql('Created database');
+          });
+        });
+
+      });
+
+    });
+
+  });
+
+  describe('polling deprovisioning status', function() {
+
+    beforeEach(function() {
+      params.last_operation = 'deprovision';
+      cp = new CmdPoll(params);
+    });
+
+    describe('an unspecified error occurs retrieving server', function() {
+
+      beforeEach(function() {
+        // Reject with an unspecified error
+        pmc.servers.get.rejects(new Error());
+      });
+
+      it('should fail', function() {
+        return cp.poll(pmc, dbc).should.be.rejected();
+      });
+
+    });
+
+    describe('server exists', function() {
+
+      beforeEach(function() {
+        // Resolve with a fake server
+        pmc.servers.get.resolves({});
+      });
+
+      it('should determine deprovisioning is in progress', function() {
+        return cp.poll(pmc, dbc).should.be.fulfilled().then((reply) => {
+          reply.state.should.equal('in progress');
+          reply.description.should.containEql('Deleting database');
+        });
+      });
+
+    });
+
+    describe('server does not exist', function() {
+
+      beforeEach(function() {
+        // Reject with a 404
+        pmc.servers.get.rejects(errNotFound);
+      });
+
+      it('should determine deprovisioning succeeded', function() {
+        return cp.poll(pmc, dbc).should.be.fulfilled().then((reply) => {
+          reply.state.should.equal('succeeded');
+          reply.description.should.containEql('Deleted database');
+        });
+      });
+
+    });
+
+  });
+
+  describe('polling with invalid last operation', function() {
+
+    beforeEach(function() {
+      params.last_operation = 'bogus';
+      cp = new CmdPoll(params);
+    });
+
+    it('should fail', function() {
+      return cp.poll(pmc, dbc).should.be.rejected();
+    });
+
+  });
+
+});

--- a/test/unit/services/azurepostgresqldb/provision-spec.js
+++ b/test/unit/services/azurepostgresqldb/provision-spec.js
@@ -1,0 +1,511 @@
+/* jshint camelcase: false */
+
+'use strict';
+
+const sinon = require('sinon');
+const should = require('should');
+require('should-sinon');
+
+const HttpStatus = require('http-status-codes');
+
+const CmdProvision = require('../../../../lib/services/azurepostgresqldb/cmd-provision');
+
+describe('PostgreSqlDb - provision command', function() {
+
+  const errNotFound = new Error();
+
+  let params;
+  let cp;
+  let rmc; // resource management client
+  let pmc; // postgresql management client
+  let dbc; // database connection factory function
+  let pc; // postgresql client
+  let provisionCallback;
+
+  before(function() {
+    errNotFound.statusCode = HttpStatus.NOT_FOUND;
+  });
+
+  beforeEach(function() {
+    params = {
+      parameters: {
+        resourceGroup: 'fake-resource-group-name',
+        location: 'westus',
+        postgresqlServerName: 'fake-server-name',
+        postgresqlServerParameters: {
+          properties: {
+            administratorLogin: 'fake-admin-name',
+            administratorLoginPassword: 'c1oudc0w'
+          },
+          allowPostgresqlServerFirewallRules: [{
+            ruleName: 'rule0',
+            startIpAddress: '1.1.1.1',
+            endIpAddress: '1.1.1.10'
+          }]
+        },
+        postgresqldbName: 'fake-db-name'
+      }
+    };
+
+    rmc = {
+      resourceGroups: {}
+    };
+    rmc.resourceGroups.get = sinon.stub();
+    rmc.resourceGroups.createOrUpdate = sinon.stub();
+
+    pmc = {
+      servers: {},
+      firewallRules: {},
+      databases: {}
+    };
+    pmc.servers.get = sinon.stub();
+    pmc.servers.createOrUpdate = sinon.stub();
+    pmc.firewallRules.createOrUpdate = sinon.stub();
+    pmc.databases.createOrUpdate = sinon.stub();
+
+    pc = {};
+    pc.query = sinon.stub();
+    pc.end = sinon.stub();
+    // Resolve query with a fake result
+    pc.query.resolves({});
+
+    dbc = sinon.stub();
+    // Factory function resolves to a fake postgres client
+    dbc.resolves(pc);
+    
+    provisionCallback = sinon.stub();
+    
+    cp = new CmdProvision(params);
+  });
+
+  describe('validation', function() {
+
+    it('should require resourceGroup', function() {
+      params.parameters.resourceGroup = null;
+      cp = new CmdProvision(params);
+      return cp.validate(pmc).should.be.rejected()
+      .then((err) => {
+        err.isValidationError.should.be.true();
+        err.invalidParams.should.deepEqual(['resourceGroup']);
+      });
+    });
+
+    it('should require location', function() {
+      params.parameters.location = null;
+      cp = new CmdProvision(params);
+      return cp.validate(pmc).should.be.rejected()
+      .then((err) => {
+        err.isValidationError.should.be.true();
+        err.invalidParams.should.deepEqual(['location']);
+      });
+    });
+
+    it('should require postgresqlServerName', function() {
+      params.parameters.postgresqlServerName = null;
+      cp = new CmdProvision(params);
+      return cp.validate(pmc).should.be.rejected()
+      .then((err) => {
+        err.isValidationError.should.be.true();
+        err.invalidParams.should.deepEqual(['postgresqlServerName']);
+      });
+    });
+
+    it('should require postgresqldbName', function() {
+      params.parameters.postgresqldbName = null;
+      cp = new CmdProvision(params);
+      return cp.validate(pmc).should.be.rejected()
+      .then((err) => {
+        err.isValidationError.should.be.true();
+        err.invalidParams.should.deepEqual(['postgresqldbName']);
+      });
+    });
+
+    it('should require administratorLogin', function() {
+      params.parameters.postgresqlServerParameters.properties.administratorLogin = null;
+      cp = new CmdProvision(params);
+      return cp.validate(pmc).should.be.rejected().
+      then((err) => {
+        err.isValidationError.should.be.true();
+        err.invalidParams.should.deepEqual(['administratorLogin']);
+      });
+    });
+
+    it('should require administratorLoginPassword', function() {
+      params.parameters.postgresqlServerParameters.properties.administratorLoginPassword = null;
+      cp = new CmdProvision(params);
+      return cp.validate(pmc).should.be.rejected()
+      .then((err) => {
+        err.isValidationError.should.be.true();
+        err.invalidParams.should.deepEqual(['administratorLoginPassword']);
+      });
+    });
+
+    describe('with firewall rules', function() {
+
+      it('should require a ruleName', function() {
+        params.parameters.postgresqlServerParameters.allowPostgresqlServerFirewallRules[0].ruleName = null;
+        cp = new CmdProvision(params);
+        return cp.validate(pmc).should.be.rejected()
+        .then((err) => {
+          err.isValidationError.should.be.true();
+          err.invalidParams.should.deepEqual(['allowPostgresqlServerFirewallRules']);
+        });
+      });
+
+      it('should require a startIpAddress', function() {
+        params.parameters.postgresqlServerParameters.allowPostgresqlServerFirewallRules[0].startIpAddress = null;
+        cp = new CmdProvision(params);
+        return cp.validate(pmc).should.be.rejected()
+        .then((err) => {
+          err.isValidationError.should.be.true();
+          err.invalidParams.should.deepEqual(['allowPostgresqlServerFirewallRules']);
+        });
+      });
+
+      it('should require a valid startIpAddress', function() {
+        params.parameters.postgresqlServerParameters.allowPostgresqlServerFirewallRules[0].startIpAddress = '1.1.1';
+        cp = new CmdProvision(params);
+        return cp.validate(pmc).should.be.rejected()
+        .then((err) => {
+          err.isValidationError.should.be.true();
+          err.invalidParams.should.deepEqual(['allowPostgresqlServerFirewallRules']);
+        });
+      });
+
+      it('should require an endIpAddress', function() {
+        params.parameters.postgresqlServerParameters.allowPostgresqlServerFirewallRules[0].endIpAddress = null;
+        cp = new CmdProvision(params);
+        return cp.validate(pmc).should.be.rejected()
+        .then((err) => {
+          err.isValidationError.should.be.true();
+          err.invalidParams.should.deepEqual(['allowPostgresqlServerFirewallRules']);
+        });
+      });
+
+      it('should require a valid endIpAddress', function() {
+        params.parameters.postgresqlServerParameters.allowPostgresqlServerFirewallRules[0].endIpAddress = '1.1.1';
+        cp = new CmdProvision(params);
+        return cp.validate(pmc).should.be.rejected()
+        .then((err) => {
+          err.isValidationError.should.be.true();
+          err.invalidParams.should.deepEqual(['allowPostgresqlServerFirewallRules']);
+        });
+      });
+
+    });
+
+    describe('unspecified error retrieving server', function() {
+
+      beforeEach(function() {
+        // Reject retrieval of server by name with unspecified error
+        pmc.servers.get.rejects(new Error());
+      });
+
+      it('should fail validation', function() {
+        return cp.validate(pmc).should.be.rejected()
+        .then((err) => {
+          should(err.isValidationError).be.undefined();
+          should(err.invalidParams).be.undefined();
+        });
+      });
+
+    });
+
+    describe('server already exists', function() {
+
+      beforeEach(function() {
+        // Resolve retrieval of server by name with a fake server
+        pmc.servers.get.resolves({});
+      });
+
+      it('should fail validation', function() {
+        return cp.validate(pmc).should.be.rejected()
+        .then((err) => {
+          err.isValidationError.should.be.true();
+          should(err.invalidParams).be.undefined();
+        });
+      });
+
+    });
+
+    describe('server does not exist', function() {
+
+      beforeEach(function() {
+        // Reject retrieval of server by name with a 404
+        pmc.servers.get.rejects(errNotFound);
+      });
+
+      it('should pass validation', function() {
+        return cp.validate(pmc).should.be.fulfilled();
+      });
+
+    });
+
+  });
+
+  describe('execution', function() {
+
+    beforeEach(function() {
+      // Resolve with a fake resource group
+      rmc.resourceGroups.get.resolves({});
+      // Resolve with a fake server
+      pmc.servers.get.resolves({});
+    });
+
+    describe('unspecified error retrieving resource group', function() {
+
+      beforeEach(function() {
+        // Reject with an unspecified error
+        rmc.resourceGroups.get.rejects(new Error());
+      });
+
+      it('should fail provisioning', function() {
+        // This will be fulfilled because after we send a response to the client
+        // we log and eat errors
+        return cp.provision(pmc, rmc, dbc, provisionCallback).should.be.rejected()
+        .then((err) => {
+          should(err.isValidationError).be.undefined();
+          // Verify we failed for the right reason and didn't get farther
+          // than we expect
+          rmc.resourceGroups.get.should.be.calledOnce();
+          provisionCallback.should.not.be.called();
+          pmc.servers.createOrUpdate.should.not.be.called();
+        });
+      });
+
+    });
+
+    describe('resource group does not exist', function() {
+
+      beforeEach(function() {
+        // Reject with a 404
+        rmc.resourceGroups.get.rejects(errNotFound);
+      });
+
+      it('should create the resource group and provisioning should succeed', function() {
+        return cp.provision(pmc, rmc, dbc, provisionCallback).should.be.fulfilled()
+        .then(() => {
+          rmc.resourceGroups.createOrUpdate.should.be.calledOnce();
+          provisionCallback.should.be.be.calledOnce();
+          pmc.servers.createOrUpdate.should.be.calledOnce();
+          pmc.firewallRules.createOrUpdate.should.be.calledOnce();
+          pmc.databases.createOrUpdate.should.be.calledOnce();
+        });
+      });
+
+    });
+
+    describe('unspecified error creating server', function() {
+
+      beforeEach(function() {
+        // Reject with an unspecified error
+        pmc.servers.createOrUpdate.rejects(new Error());
+      });
+
+      it('should fail provisioning', function() {
+        // This will be fulfilled because after we send a response to the client
+        // we log and eat errors
+        return cp.provision(pmc, rmc, dbc, provisionCallback).should.be.fulfilled()
+        .then((err) => {
+          // Even though the promise wasn't rejected, we'll at least expect it
+          // to resolve to an Error in this case
+          err.should.be.instanceOf(Error);
+          should(err.isValidationError).be.undefined();
+          // Verify we failed for the right reason and didn't get farther
+          // than we expect
+          pmc.servers.createOrUpdate.should.be.calledOnce();
+          pmc.servers.get.should.not.be.called();
+        });
+      });
+
+    });
+
+    describe('unspecified error retrieving server', function() {
+
+      beforeEach(function() {
+        // Reject retrieval of server by name with unspecified error
+        pmc.servers.get.rejects(new Error());
+      });
+
+      it('should fail provisioning', function() {
+        // This will be fulfilled because after we send a response to the client
+        // we log and eat errors
+        return cp.provision(pmc, rmc, dbc, provisionCallback).should.be.fulfilled()
+        .then((err) => {
+          // Even though the promise wasn't rejected, we'll at least expect it
+          // to resolve to an Error in this case
+          err.should.be.instanceOf(Error);
+          should(err.isValidationError).be.undefined();
+          // Verify we failed for the right reason and didn't get farther
+          // than we expect
+          pmc.servers.get.should.be.calledOnce();
+          pmc.firewallRules.createOrUpdate.should.not.be.called();
+        });
+      });
+
+    });
+
+    describe('no firewall rules specified', function() {
+
+      beforeEach(function() {
+        delete params.parameters.postgresqlServerParameters.allowPostgresqlServerFirewallRules;
+        cp = new CmdProvision(params);
+      });
+
+      it('should not create any firewall rules and provisioning should succeed', function() {
+        return cp.provision(pmc, rmc, dbc, provisionCallback).should.be.fulfilled()
+        .then(() => {
+          rmc.resourceGroups.createOrUpdate.should.not.be.called();
+          provisionCallback.should.be.be.calledOnce();
+          pmc.servers.createOrUpdate.should.be.calledOnce();
+          pmc.firewallRules.createOrUpdate.should.not.be.called();
+          pmc.databases.createOrUpdate.should.be.calledOnce();
+        });
+      });
+
+    });
+
+    describe('multiple firewall rules', function() {
+
+      beforeEach(function() {
+        params.parameters.postgresqlServerParameters.allowPostgresqlServerFirewallRules.push({
+          ruleName: 'rule1',
+          startIpAddress: '2.2.2.2',
+          endIpAddress: '2.2.2.10'
+        });
+        cp = new CmdProvision(params);
+      });
+
+      it('should create multiple firewall rules and provisioning should succeed', function() {
+        return cp.provision(pmc, rmc, dbc, provisionCallback).should.be.fulfilled()
+        .then(() => {
+          rmc.resourceGroups.createOrUpdate.should.not.be.called();
+          provisionCallback.should.be.be.calledOnce();
+          pmc.servers.createOrUpdate.should.be.calledOnce();
+          pmc.firewallRules.createOrUpdate.should.be.calledTwice();
+          pmc.databases.createOrUpdate.should.be.calledOnce();
+        });
+      });
+
+    });
+
+    describe('unspecified error creating firewall rules', function() {
+
+      beforeEach(function() {
+        // Reject with an unspecified error
+        pmc.firewallRules.createOrUpdate.rejects(new Error());
+      });
+
+      it('should fail provisioning', function() {
+        // This will be fulfilled because after we send a response to the client
+        // we log and eat errors
+        return cp.provision(pmc, rmc, dbc, provisionCallback).should.be.fulfilled()
+        .then((err) => {
+          // Even though the promise wasn't rejected, we'll at least expect it
+          // to resolve to an Error in this case
+          err.should.be.instanceOf(Error);
+          should(err.isValidationError).be.undefined();
+          // Verify we failed for the right reason and didn't get farther
+          // than we expect
+          pmc.firewallRules.createOrUpdate.should.be.calledOnce();
+          pmc.databases.createOrUpdate.should.not.be.called();
+        });
+      });
+
+    });
+
+    describe('unspecified error creating database', function() {
+
+      beforeEach(function() {
+        // Reject with an unspecified error
+        pmc.databases.createOrUpdate.rejects(new Error());
+      });
+
+      it('should fail provisioning', function() {
+        // This will be fulfilled because after we send a response to the client
+        // we log and eat errors
+        return cp.provision(pmc, rmc, dbc, provisionCallback).should.be.fulfilled()
+        .then((err) => {
+          should(err.isValidationError).be.undefined();
+          // Even though the promise wasn't rejected, we'll at least expect it
+          // to resolve to an Error in this case
+          err.should.be.instanceOf(Error);
+          // Verify we failed for the right reason and didn't get farther
+          // than we expect
+          pmc.databases.createOrUpdate.should.be.calledOnce();
+          pc.query.should.not.be.called();
+        });
+      });
+
+    });
+
+    describe('error connecting to the database', function() {
+
+      beforeEach(function() {
+        // Rejects with an unspecified error
+        dbc.rejects(new Error());
+      });
+
+      it('should fail provisioning', function() {
+        return cp.provision(pmc, rmc, dbc, provisionCallback).should.be.fulfilled()
+        .then((err) => {
+          should(err.isValidationError).be.undefined();
+          // Even though the promise wasn't rejected, we'll at least expect it
+          // to resolve to an Error in this case
+          err.should.be.instanceOf(Error);
+          dbc.should.be.calledOnce();
+          pc.query.should.not.be.called();
+          pc.end.should.not.be.called();
+        });
+      });
+
+    });
+
+    describe('unspecified error managing database', function() {
+
+      beforeEach(function() {
+        // The first call starts the transaction
+        pc.query.onCall(0).resolves({});
+        // The second call errors
+        pc.query.onCall(1).rejects(new Error());
+        // The third call rolls the transaction back
+        pc.query.onCall(2).resolves({});
+      });
+
+      it('should fail provisioning', function() {
+        // This will be fulfilled because after we send a response to the client
+        // we log and eat errors
+        return cp.provision(pmc, rmc, dbc, provisionCallback).should.be.fulfilled()
+        .then((err) => {
+          should(err.isValidationError).be.undefined();
+          // Even though the promise wasn't rejected, we'll at least expect it
+          // to resolve to an Error in this case
+          err.should.be.instanceOf(Error);
+          // query function should be called x 3:
+          // 0. Start the transaction
+          // 1. Bad query
+          // 2. Rollback
+          pc.query.should.be.calledThrice();
+        });
+      });
+
+    });
+
+    // This is for the completely average case-- resource group exists, one
+    // firewall rule, and no errors
+    it('should provision', function() {
+      return cp.provision(pmc, rmc, dbc, provisionCallback).should.be.fulfilled()
+      .then(() => {
+        rmc.resourceGroups.createOrUpdate.should.not.be.called();
+        provisionCallback.should.be.be.calledOnce();
+        pmc.servers.createOrUpdate.should.be.calledOnce();
+        pmc.servers.get.should.be.calledOnce();
+        pmc.firewallRules.createOrUpdate.should.be.calledOnce();
+        pmc.databases.createOrUpdate.should.be.calledOnce();
+        pc.query.should.have.callCount(5);
+      });
+    });
+
+  });
+
+});

--- a/test/unit/services/azurepostgresqldb/unbind-spec.js
+++ b/test/unit/services/azurepostgresqldb/unbind-spec.js
@@ -1,0 +1,88 @@
+/* jshint camelcase: false */
+
+'use strict';
+
+const sinon = require('sinon');
+require('should');
+require('should-sinon');
+
+const CmdUnbind = require('../../../../lib/services/azurepostgresqldb/cmd-unbind');
+
+describe('PostgreSqlDb - unbind command', function() {
+
+  let params;
+  let dbc; // database connection factory function
+  let pc; // postgresql client
+  let cu;
+
+  beforeEach(function() {
+    params = {
+      provisioning_result: {
+        resourceGroup: 'fake-resource-group-name',
+        postgresqlServerName: 'fake-server-name',
+        postgresqldbName: 'fake-db-name'
+      },
+      binding_result: {
+        databaseLogin: 'fake-db-user'
+      }
+    };
+
+    pc = {};
+    pc.query = sinon.stub();
+    pc.end = sinon.stub();
+    // Resolve query with a fake result
+    pc.query.resolves({});
+
+    dbc = sinon.stub();
+    // Factory function resolves to a fake postgres client
+    dbc.resolves(pc);
+    
+    cu = new CmdUnbind(params);
+  });
+
+  it('should unbind', function() {
+    return cu.unbind(dbc).should.be.fulfilled()
+    .then(() => {
+      dbc.should.be.calledOnce();
+      pc.query.should.have.calledOnce();
+      pc.end.should.be.calledOnce();
+    });
+  });
+
+  describe('error connecting to the database', function() {
+
+    beforeEach(function() {
+      // Rejects with an unspecified error
+      dbc.rejects(new Error());
+    });
+
+    it('should not unbind', function() {
+      return cu.unbind(dbc).should.be.rejected()
+      .then(() => {
+        dbc.should.be.calledOnce();
+        pc.query.should.not.be.called();
+        pc.end.should.not.be.called();
+      });
+    });
+
+  });
+
+  describe('unspecified error', function() {
+
+    beforeEach(function() {
+      // Rejects with an unspecified error
+      pc.query.rejects(new Error());
+    });
+
+    it('should not unbind', function() {
+      return cu.unbind(dbc).should.be.rejected()
+      .then(() => {
+        dbc.should.be.calledOnce();
+        pc.query.should.be.calledOnce();
+        pc.end.should.be.calledOnce();
+      });
+    });
+
+  });
+
+});

--- a/test/utils/azurepostgresqldbClient.js
+++ b/test/utils/azurepostgresqldbClient.js
@@ -1,0 +1,70 @@
+const common = require('../../lib/common');
+const statusCode = require('./statusCode');
+const pg = require('pg');
+
+module.exports = function(environment) {
+  let log = common.getLogger('azurepostgresqldbClient');
+
+  this.validateCredential = function(credentials, next) {
+
+    let client = new pg.Client({
+      host: credentials.postgresqlServerFullyQualifiedDomainName,
+      database: credentials.postgresqldbName,
+      user: credentials.databaseLogin + '@' + credentials.postgresqlServerName,
+      password: credentials.databaseLoginPassword,
+      ssl: true
+    });
+
+    new Promise((resolve, reject) => {
+      client.connect(function (err) {
+        if (err) {
+          reject(err);
+        } else {
+          // Workaround: Mainly during testing, encountering many cases of
+          // connection reset by peer. We'll log and eat errors from IDLE
+          // connections. This should be a harmless thing to do. The broker
+          // doesn't interact with any given Postgres database with any real
+          // frequency, so we use no connection pooling. i.e. Every connection
+          // is intended to standalone and be discarded after a single use
+          // anyway. Note that this will not eat errors caused by a query.
+          // Those will still be handled by the catch in the promise chain.
+          client.on('error', function(err) {
+            log.warn(err);
+          });
+          resolve();
+        }
+      });
+    })
+    .then(() => {
+      return client.query('CREATE TABLE testtable(aaa char(10))');
+    })
+    .then(() => {
+      log.debug('The user can create a new table in the PostgreSQL database.');
+      return client.query('INSERT INTO testtable(aaa) values (\'bbb\')');
+    })
+    .then(() => {
+      log.debug('The user can insert a new row to the new table.');
+      return client.query('SELECT * FROM testtable');
+    })
+    .then(() => {
+      log.debug('The user can get the row inserted.');
+      client.end(function(err){
+        if (err) {
+          log.error(err);
+        }
+        setTimeout(next, 5000, statusCode.PASS);
+      });
+    })
+    .catch((err) => {
+      log.error(err);
+      next(statusCode.FAIL);
+      client.end(function(err){
+        if (err) {
+          log.error(err);
+        }
+      });
+    });
+
+  };
+
+};

--- a/test/utils/clients.js
+++ b/test/utils/clients.js
@@ -3,6 +3,7 @@ var AzureservicebusClient = require('./azureservicebusClient');
 var AzurerediscacheClient = require('./azurerediscacheClient');
 var AzuredocdbClient = require('./azuredocdbClient');
 var AzuresqldbClient = require('./azuresqldbClient');
+var AzurepostgresqldbClient = require('./azurepostgresqldbClient');
 
 var environment = process.env['ENVIRONMENT'];
 
@@ -11,5 +12,6 @@ module.exports = {
   'azure-servicebus': new AzureservicebusClient(environment),
   'azure-rediscache': new AzurerediscacheClient(),
   'azure-documentdb': new AzuredocdbClient(),
-  'azure-sqldb': new AzuresqldbClient(environment)
+  'azure-sqldb': new AzuresqldbClient(environment),
+  'azure-postgresqldb': new AzurepostgresqldbClient(environment)
 };


### PR DESCRIPTION
@arschles asked me to PR this just to get it on your radar.

This isn't mergeable because it was built in parallel with your own postgres module (i.e. not built on top of it... much of this was written before I realized you guys were already working on one). _If_ there's interest in moving forward with this, I'm happy to rebase on master.

The implementation is a bit different from what's in master now: it uses ES6 and the Node SDK for "Azure Database for PostgreSQL". That SDK didn't exist prior to this effort. I generated it (and an SDK for MySQL also) from swagger specs and worked with the [azure-sdk-for-node](https://github.com/Azure/azure-sdk-for-node) team to get those new SDKs merged. Note that they are not yet published to NPM. (I'm working on that still.) These SDKs are promise-based, so you will find much of the code in this implementation is promise-based as well.

More significant than the differences in implementation, however, are the differences in scope. What's in master currently only provisions PostgreSQL servers. I opened issue #114 about this because applications that may need to provision and bind to a database generally expect the database to exist and don't posses the intelligence to begin with a fresh server and create and manage the database themselves. So, in terms of scope, this alternative implementation includes provisioning a database as as well (1:1 server:database). Because applications that bind to the service also shouldn't necessarily need administrative privileges, binding is also different in this implementation. Here, binding provides a new, unique set of credentials that can be revoked upon unbind.

It's also worth highlighting what is _common_ to this implementation and what is in master-- I have re-used your `service.json` and also ensured that my implementation honors the _exact_ same parameters as the implementation that's in master. (You need to provide only one additional provisioning parameter-- `postgressqldbName`.)

fwiw, I assume there's some pride in ownership of the postgres module that's in master now and this is a very different implementation. If we could consider merging this eventually, I'd be happy, but I'd be equally happy if we can build on what's in master now to close all the (perceived) gaps this PR addresses...

Bottom line is I'd love this to get merged, but what I care about most is that we use this PR to stimulate further discussion.