### PR TITLE
allow operator set default parameters for each module in manifest

### DIFF
--- a/docs/azure-cosmos-db.md
+++ b/docs/azure-cosmos-db.md
@@ -81,15 +81,21 @@
 
   ```
   {
-    "resourceGroup": "my-resource-group-name",
-    "cosmosDbAccountName": "cosmosdbaccount123",
-    "cosmosDbName": "cosmosdb123",
-    "location": "westus",
+    "resourceGroup": "azure-service-broker",
+    "cosmosDbAccountName": "generated-string",
+    "cosmosDbName": "generated-string",
+    "location": "eastus",
     "kind": "DocumentDB"
   }
   ```
-
+  
   >**NOTE:** Please remove the comments in the JSON file before you use it.
+  
+  Above parameters are also the defaults if the broker operator doesn't change broker default settings. You can just run the following command to create a service instance without the json file:
+  
+  ```
+  cf create-service azure-cosmosdb standard mycosmosdb
+  ```
 
 3. Check the operation status of creating the service instance
 

--- a/docs/azure-document-db.md
+++ b/docs/azure-document-db.md
@@ -80,14 +80,20 @@
 
   ```
   {
-    "resourceGroup": "my-resource-group-name",
-    "docDbAccountName": "docdbaccount123",
-    "docDbName": "docdb123",
-    "location": "westus"
+    "resourceGroup": "azure-service-broker",
+    "docDbAccountName": "generated-string",
+    "docDbName": "generated-string",
+    "location": "eastus"
   }
   ```
 
   >**NOTE:** Please remove the comments in the JSON file before you use it.
+
+  Above parameters are also the defaults if the broker operator doesn't change broker default settings. You can just run the following command to create a service instance without the json file:
+  
+  ```
+  cf create-service azure-documentdb standard mydocdb
+  ```
 
 3. Check the operation status of creating the service instance
 

--- a/docs/azure-mysql-db.md
+++ b/docs/azure-mysql-db.md
@@ -108,13 +108,13 @@
 
   ```
   {
-      "resourceGroup": "mysqldbResourceGroup",
-      "location": "westus",
-      "mysqlServerName": "mysqlservera",
+      "resourceGroup": "azure-service-broker",
+      "location": "eastus",
+      "mysqlServerName": "generated-string",
       "mysqlServerParameters": {
           "allowMysqlServerFirewallRules": [
               {
-                "ruleName": "newrule",
+                "ruleName": "all",
                 "startIpAddress": "0.0.0.0",
                 "endIpAddress": "255.255.255.255"
               }
@@ -123,16 +123,20 @@
               "version": "5.6",
               "sslEnforcement": "Disabled",
               "storageMB": 51200,
-              "administratorLogin": "myusername",
-              "administratorLoginPassword": "myPASSw0rd"
+              "administratorLogin": "generated-string",
+              "administratorLoginPassword": "generated-string"
           }
       }
   }
   ```
 
-**NOTE:**
-
-  * Please remove the comments in the JSON file before you use it.
+  >**NOTE:** Please remove the comments in the JSON file before you use it.
+  
+  Above parameters are also the defaults if the broker operator doesn't change broker default settings. You can just run the following command to create a service instance without the json file:
+  
+  ```
+  cf create-service azure-mysqldb basic100 mysqldb
+  ```
 
 3. Check the operation status of creating the service instance
 

--- a/docs/azure-postgresql-db.md
+++ b/docs/azure-postgresql-db.md
@@ -101,13 +101,13 @@
 
   ```
   {
-      "resourceGroup": "postgresqldbResourceGroup",
-      "location": "westus",
-      "postgresqlServerName": "postgresqlservera",
+      "resourceGroup": "azure-service-broker",
+      "location": "eastus",
+      "postgresqlServerName": "generated-string",
       "postgresqlServerParameters": {
           "allowPostgresqlServerFirewallRules": [
               {
-                "ruleName": "newrule",
+                "ruleName": "all",
                 "startIpAddress": "0.0.0.0",
                 "endIpAddress": "255.255.255.255"
               }
@@ -116,16 +116,20 @@
               "version": "9.6",
               "sslEnforcement": "Disabled",
               "storageMB": 51200,
-              "administratorLogin": "myusername",
-              "administratorLoginPassword": "myPASSw0rd"
+              "administratorLogin": "generated-string",
+              "administratorLoginPassword": "generated-string"
           }
       }
   }
   ```
 
-**NOTE:**
-
-  * Please remove the comments in the JSON file before you use it.
+  >**NOTE:** Please remove the comments in the JSON file before you use it.
+  
+  Above parameters are also the defaults if the broker operator doesn't change broker default settings. You can just run the following command to create a service instance without the json file:
+  
+  ```
+  cf create-service azure-postgresqldb basic100 postgresqldb
+  ```
 
 3. Check the operation status of creating the service instance
 

--- a/docs/azure-redis-cache.md
+++ b/docs/azure-redis-cache.md
@@ -62,9 +62,9 @@
   ```
   {
     "resourceGroup": "<resource-group-name>", // [Required] Unique. Only allow up to 90 characters
+    "location": "<location>",                 // [Required] e.g. eastasia, eastus2, westus, etc. You can use azure cli command 'azure location list' to list all locations.
     "cacheName": "<cache-name>",              // [Required] Unique. Must be between 3 and 63 characters long. Can only contain numbers, letters, and the - character. The cache name cannot start or end with the - character, and consecutive - characters are not valid.
     "parameters": {
-      "location": "<location>",               // [Required] e.g. eastasia, eastus2, westus, etc. You can use azure cli command 'azure location list' to list all locations.
       "enableNonSslPort": true | false,
       "sku": {                                // [Required] EXAMPLE: Basic C 0 for cache size 250MB, low network performance and 256 client connections. See more skus: https://azure.microsoft.com/en-us/pricing/details/cache/
         "name": "<sku-name>",
@@ -85,10 +85,10 @@
 
   ```
   {
-    "resourceGroup": "redisResourceGroup",
-    "cacheName": "mycache",
+    "resourceGroup": "azure-service-broker",
+    "location": "eastus",
+    "cacheName": "generated-string",
     "parameters": {
-      "location": "eastus",
       "enableNonSslPort": false,
       "sku": {
         "name": "Basic",
@@ -100,6 +100,12 @@
   ```
   
   >**NOTE:** Please remove the comments in the JSON file before you use it.
+  
+  Above parameters are also the defaults if the broker operator doesn't change broker default settings. You can just run the following command to create a service instance without the json file:
+  
+  ```
+  cf create-service azure-rediscache basic myrediscache
+  ```
 
 3. Check the operation status of creating the service instance
 

--- a/docs/azure-service-bus.md
+++ b/docs/azure-service-bus.md
@@ -60,11 +60,11 @@
   Supported configuration parameters:
   ```
   {
-    "resource_group_name": "<resource-group-name>", // [Required] Only allow up to 90 characters
-    "namespace_name": "<namespace-name>", // [Required] Between 6 and 50 characters long
-    "location": "<location>",             // [Required] e.g. eastasia, eastus2, westus, etc. You can use azure cli command 'azure location list' to list all locations.
-    "type": "<type>",                     // [Required] Possible values are `Messaging`, `EventHub` and `NotificationHub`
-    "messaging_tier": "<messaging-tier>"  // [Required] Possible values are `Basic`, `Standard` and `Premium` for type `Messaging`, `Basic` and `Standard` for type `EventHub`, `Standard` for type `NotificationHub`.
+    "resourceGroup": "<resource-group-name>", // [Required] Only allow up to 90 characters
+    "namespaceName": "<namespace-name>",      // [Required] Between 6 and 50 characters long
+    "location": "<location>",                 // [Required] e.g. eastasia, eastus2, westus, etc. You can use azure cli command 'azure location list' to list all locations.
+    "type": "<type>",                         // [Required] Possible values are `Messaging`, `EventHub` and `NotificationHub`
+    "messagingTier": "<messaging-tier>"       // [Required] Possible values are `Basic`, `Standard` and `Premium` for type `Messaging`, `Basic` and `Standard` for type `EventHub`, `Standard` for type `NotificationHub`.
   }
   ```
 
@@ -81,16 +81,26 @@
 
   ```
   {
-    "resource_group_name": "myResourceGroup",
-    "namespace_name": "myservicebus",
+    "resourceGroup": "azure-service-broker",
+    "namespaceName": "generated-string",
     "location": "eastus",
     "type": "Messaging",
-    "messaging_tier": "Standard"
+    "messagingTier": "Standard"
   }
   ```
 
-  >**NOTE:** Please remove the comments in the JSON file before you use it.
+  >**NOTE:**
+  
+    * Please remove the comments in the JSON file before you use it.
+    
+    * The names of parameters "resource_group_name", "namespace_name",and "messaging_tier" are deprecated since their formats are not unified with other services.
 
+  Above parameters are also the defaults if the broker operator doesn't change broker default settings. You can just run the following command to create a service instance without the json file:
+  
+  ```
+  cf create-service azure-servicebus standard myservicebus
+  ```
+  
 3. Check the operation status of creating the service instance
 
   The creating operation is asynchronous. You can get the operation status after the creating operation.

--- a/docs/azure-sql-db.md
+++ b/docs/azure-sql-db.md
@@ -86,12 +86,14 @@ azure-sqldb     basic*, StandardS0*, StandardS1*, StandardS2*, StandardS3*, Prem
 
 2. Create a service instance
 
+#### Create a datbase on a new server
+
   Configuration parameters are supported with the provision request. These parameters are passed in a valid JSON object containing configuration parameters, provided either in-line or in a file.
 
   ```
   cf create-service azure-sqldb $service_plan $service_instance_name -c $path_to_parameters
   ```
-
+  
   Supported configuration parameters:
 
   ```
@@ -137,34 +139,29 @@ azure-sqldb     basic*, StandardS0*, StandardS1*, StandardS2*, StandardS3*, Prem
 
   ```
   {
-    "resourceGroup": "sqldbResourceGroup",
-    "location": "westus",
-    "sqlServerName": "sqlservera",
-    "sqlServerParameters": {
-        "allowSqlServerFirewallRules": [
-            {
-                "ruleName": "rule0",
-                "startIpAddress": "1.1.1.1",
-                "endIpAddress": "1.1.1.10"
-            },
-            {
-                "ruleName": "rule1",
-                "startIpAddress": "2.2.2.2",
-                "endIpAddress": "2.2.2.20"
-            },
-        ],
-        "properties": {
-            "administratorLogin": "myusername",
-            "administratorLoginPassword": "mypassword"
-        }
-    },
-    "sqldbName": "sqlDbA",
-    "transparentDataEncryption": true,
-    "sqldbParameters": {
-        "properties": {
-            "collation": "SQL_Latin1_General_CP1_CI_AS"
-        }
-    }
+      "resourceGroup": "azure-service-broker",
+      "location": "eastus",
+      "sqlServerName": "generated-string",
+      "sqlServerParameters": {
+          "allowSqlServerFirewallRules": [
+              {
+                  "ruleName": "all",
+                  "startIpAddress": "0.0.0.0",
+                  "endIpAddress": "255.255.255.255"
+              }
+          ],
+          "properties": {
+              "administratorLogin": "generated-string",
+              "administratorLoginPassword": "generated-string"
+          }
+      },
+      "sqldbName": "generated-string",
+      "transparentDataEncryption": true,
+      "sqldbParameters": {
+          "properties": {
+              "collation": "SQL_Latin1_General_CP1_CI_AS"
+          }
+      }
   }
   ```
 
@@ -183,6 +180,50 @@ azure-sqldb     basic*, StandardS0*, StandardS1*, StandardS2*, StandardS3*, Prem
   * If you want to set more child parameters in sqldbParameters, see details here: https://msdn.microsoft.com/en-us/library/azure/mt163685.aspx
 
   * Please remove the comments in the JSON file before you use it.
+  
+  Above parameters are also the defaults if the broker operator doesn't change broker default settings. You can just run the following command to create a service instance without the json file:
+  
+  ```
+  cf create-service azure-sqldb basic mysqldb
+  ```
+  
+#### Create a datbase on am existing server
+
+  Parameters can be simpler:
+  
+  ```
+  {
+      "sqlServerName": "<sql-server-name>",       // [Required] Unique. sqlServerName cannot be empty or null. It can contain only lowercase letters, numbers and '-', but can't start or end with '-' or have more than 63 characters. 
+      "sqldbName": "<sql-database-name>",         // [Required] Not more than 128 characters. Can't end with '.' or ' ', can't contain '<,>,*,%,&,:,\,/,?' or control characters.
+      "transparentDataEncryption": true | false,  // Enable Transparent Data Encryption on the database. If not present, it follows the broker manifest. Defaults to false. 
+      "sqldbParameters": {                        // If you want to set more child parameters, see details here: https://msdn.microsoft.com/en-us/library/azure/mt163685.aspx
+          "properties": {
+              "collation": "SQL_Latin1_General_CP1_CI_AS | <or-other-valid-sqldb-collation>"
+          }
+      }
+  }
+  ```
+  
+  For example, to create a database on the existing server named `sqlservera`:
+  
+  ```
+  {
+      "sqlServerName": "sqlservera",
+      "sqldbName": "generated-string",
+      "transparentDataEncryption": true,
+      "sqldbParameters": {
+          "properties": {
+              "collation": "SQL_Latin1_General_CP1_CI_AS"
+          }
+      }
+  }
+  ```
+  
+  Above parameters are also the defaults if the broker operator doesn't change broker default settings. You can just run the following command to create a service instance without the json file:
+  
+  ```
+  cf create-service azure-sqldb basic mysqldb -c '{"sqlServerName": "sqlservera"}'
+  ```
 
 3. Check the operation status of creating the service instance
 

--- a/docs/azure-storage.md
+++ b/docs/azure-storage.md
@@ -61,10 +61,10 @@
 
   ```
   {
-    "resource_group_name": "<resource-group-name>",   // [Required] Unique. Only allow up to 90 characters
-    "storage_account_name": "<storage-account-name>", // [Required] Unique. Can contain only lowercase letters and numbers. Name must be between 3 and 24 characters.
-    "location": "<location>",                         // [Required] e.g. eastasia, eastus2, westus, etc. You can use azure cli command 'azure location list' to list all locations.
-    "account_type": "Standard_LRS | <other-account-type>"  // [Required] Possible value: Standard_LRS | Standard_ZRS | Standard_GRS | Standard_RAGRS | Premium_LRS . See more details: https://azure.microsoft.com/en-us/pricing/details/storage/
+    "resourceGroup": "<resource-group-name>",             // [Required] Unique. Only allow up to 90 characters
+    "storageAccountName": "<storage-account-name>",       // [Required] Unique. Can contain only lowercase letters and numbers. Name must be between 3 and 24 characters.
+    "location": "<location>",                             // [Required] e.g. eastasia, eastus2, westus, etc. You can use azure cli command 'azure location list' to list all locations.
+    "accountType": "Standard_LRS | <other-account-type>"  // [Required] Possible value: Standard_LRS | Standard_ZRS | Standard_GRS | Standard_RAGRS | Premium_LRS . See more details: https://azure.microsoft.com/en-us/pricing/details/storage/
   }
   ```
 
@@ -78,14 +78,24 @@
 
   ```
   {
-    "resource_group_name": "myResourceGroup",
-    "storage_account_name": "mystorageaccount",
+    "resourceGroup": "azure-service-broker",
+    "storageAccountName": "generated-string",
     "location": "eastus",
-    "account_type": "Standard_LRS"
+    "accountType": "Standard_LRS"
   }
   ```
 
-  >**NOTE:** Please remove the comments in the JSON file before you use it.
+  >**NOTE:**
+  
+    * Please remove the comments in the JSON file before you use it.
+    
+    * The names of parameters "resource_group_name", "storage_account_name",and "account_type" are deprecated since their formats are not unified with other services.
+  
+  Above parameters are also the defaults if the broker operator doesn't change broker default settings. You can just run the following command to create a service instance without the json file:
+  
+  ```
+  cf create-service azure-storage standard mystorageservice
+  ```
 
 3. Check the operation status of creating the service instance
 
@@ -128,7 +138,7 @@ In the application, you can use Azure SDK for Python to operate your storage acc
   ```
   service_name = 'azure-storage'
   vcap_services = json.loads(os.environ['VCAP_SERVICES'])
-  account_name = vcap_services[service_name][0]['credentials']['storage_account_name']
+  account_name = vcap_services[service_name][0]['credentials']['storageAccountName']
   account_key = vcap_services[service_name][0]['credentials']['primary_access_key']
   ```
 

--- a/docs/how-admin-deploy-the-broker.md
+++ b/docs/how-admin-deploy-the-broker.md
@@ -165,7 +165,7 @@
 
     * Modules related configurations
 
-      Only SQL database service has the configurations for now. The default value of `AZURE_SQLDB_ALLOW_TO_CREATE_SQL_SERVER` is `true`. The default value of `AZURE_SQLDB_ENABLE_TRANSPARENT_DATA_ENCRYPTION` is `false`. `AZURE_SQLDB_SQL_SERVER_POOL` is an array of SQL server credentials. Each element in the array should contain all the five parameters: resourceGroup, location, sqlServerName, administratorLogin and administratorLoginPassword.
+      It is allow to pre-configure some SQL server credentials for SQL database service. The default value of `AZURE_SQLDB_ALLOW_TO_CREATE_SQL_SERVER` is `true`. The default value of `AZURE_SQLDB_ENABLE_TRANSPARENT_DATA_ENCRYPTION` is `false`. `AZURE_SQLDB_SQL_SERVER_POOL` is an array of SQL server credentials. Each element in the array should contain all the five parameters: resourceGroup, location, sqlServerName, administratorLogin and administratorLoginPassword.
 
       ```
       AZURE_SQLDB_ALLOW_TO_CREATE_SQL_SERVER: true | false
@@ -186,6 +186,89 @@
           "administratorLoginPassword": "REPLACE-ME"
         }
       ]'
+      ```
+      
+    * Modules default parameters
+    
+      Default parameters can be set. Please refer the configuration files in the docs for these modules.
+    
+      ```
+      ALLOW_TO_GENERATE_NAMES_AND_PASSWORDS_FOR_THE_MISSING: true
+    
+      DEFAULT_RESOURCE_GROUP: azure-service-broker
+      DEFAULT_LOCATION: eastus
+      
+      DEFAULT_PARAMETERS_AZURE_REDISCACHE: '{
+          "parameters": {
+              "enableNonSslPort": false,
+              "sku": {
+                  "name": "Basic",
+                  "family": "C",
+                  "capacity": 0
+              }
+          }
+      }'
+      DEFAULT_PARAMETERS_AZURE_SERVICEBUS: '{
+          "type": "Messaging",
+          "messagingTier": "Standard"
+      }'
+      DEFAULT_PARAMETERS_AZURE_STORAGE: '{
+          "accountType": "Standard_LRS"
+      }'
+      DEFAULT_PARAMETERS_AZURE_DOCDB: '{
+      }'
+      DEFAULT_PARAMETERS_AZURE_COSMOSDB: '{
+          "kind": "DocumentDB"
+      }'
+      DEFAULT_PARAMETERS_AZURE_MYSQLDB: '{
+          "mysqlServerParameters": {
+              "allowMysqlServerFirewallRules": [
+                  {
+                    "ruleName": "all",
+                    "startIpAddress": "0.0.0.0",
+                    "endIpAddress": "255.255.255.255"
+                  }
+              ],
+              "properties": {
+                  "version": "5.6",
+                  "sslEnforcement": "Disabled",
+                  "storageMB": 51200
+              }
+          }
+      }'
+      DEFAULT_PARAMETERS_AZURE_POSTGRESQLDB: '{
+          "postgresqlServerParameters": {
+              "allowPostgresqlServerFirewallRules": [
+                  {
+                    "ruleName": "all",
+                    "startIpAddress": "0.0.0.0",
+                    "endIpAddress": "255.255.255.255"
+                  }
+              ],
+              "properties": {
+                  "version": "9.6",
+                  "sslEnforcement": "Disabled",
+                  "storageMB": 51200
+              }
+          }
+      }'
+      DEFAULT_PARAMETERS_AZURE_SQLDB: '{
+          "sqlServerParameters": {
+              "allowSqlServerFirewallRules": [
+                  {
+                      "ruleName": "all",
+                      "startIpAddress": "0.0.0.0",
+                      "endIpAddress": "255.255.255.255"
+                  }
+              ]
+          },
+          "transparentDataEncryption": true,
+          "sqldbParameters": {
+              "properties": {
+                  "collation": "SQL_Latin1_General_CP1_CI_AS"
+              }
+          }
+      }'
       ```
 
 1. Install the Node dependencies for production environment.

--- a/docs/service-module-design.md
+++ b/docs/service-module-design.md
@@ -127,8 +127,8 @@ It should be an asynchronous operation.
       "service_id":"2e2fc314-37b6-4587-8127-8f9ee8b33fea",
       "space_guid":"66577389-4c40-4096-a75b-ab6f6ab97f9c",
       "parameters":{
-        "resource_group_name":"binxi031401",
-        "storage_account_name":"binxi031401sa"
+        "resourceGroup":"binxi031401",
+        "storageAccountName":"binxi031401sa"
       },
       "azure":{
         "ENVIRONMENT":"AzureCloud",
@@ -198,9 +198,9 @@ Handlers.poll = function(params, next)
   }
   ```
 
-  * If the last operation is provision, you can query the provisioning state of the service instance by name (e.g. resource_group_name /storage_account_name).
+  * If the last operation is provision, you can query the provisioning state of the service instance by name (e.g. resourceGroup /storageAccountName).
 
-  * If the last operation is deprovision, you can query the deprovisioning state of the service instance by name (e.g. resource_group_name /storage_account_name).
+  * If the last operation is deprovision, you can query the deprovisioning state of the service instance by name (e.g. resourceGroup /storageAccountName).
 
 * next(err, reply, result)
 
@@ -337,7 +337,7 @@ Handlers.bind = function(params, next)
       code: "Created",
       value: {
         credentials: {
-          storage_account_name: storageAccountName,
+          storageAccountName: storageAccountName,
           primary_access_key: primaryAccessKey,
           secondary_access_key: secondaryAccessKey,
         }
@@ -345,7 +345,7 @@ Handlers.bind = function(params, next)
     }
     ```
 
-    The contents of the credentials should be determined by your service module. Applications can use these credentials to access the service instance. E.g. For Azure storage service, the credentials are storage_account_name, primary_access_key and secondary_access_key. For SQL server service, the credentials should be the connection string.
+    The contents of the credentials should be determined by your service module. Applications can use these credentials to access the service instance. E.g. For Azure storage service, the credentials are storageAccountName, primary_access_key and secondary_access_key. For SQL server service, the credentials should be the connection string.
 
   * result should be a valid JSON object which is determined by the service module.
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -163,7 +163,7 @@ The following sections describe common issues you might encounter when attemptin
     for example:
   
     ```
-    SELECT * FROM instances WHERE parameters LIKE '%"storage_account_name":"storageil3l080br05no4n1"%'
+    SELECT * FROM instances WHERE parameters LIKE '%"storageAccountName":"storageil3l080br05no4n1"%'
     ```
   
     If deleting failed because of foreign key, please use following SQL to delete the corresponding record in the table **bindings**:

--- a/examples/cosmosdb-example-config.json
+++ b/examples/cosmosdb-example-config.json
@@ -9,9 +9,9 @@
 */
 // Please delete all the comments before using this .json to create service instance.
 {
-  "resourceGroup": "my-resource-group-name",
-  "cosmosDbAccountName": "cosmosdbaccount123",
-  "cosmosDbName": "cosmosdb123",
-  "location": "westus",
+  "resourceGroup": "azure-service-broker",
+  "cosmosDbAccountName": "generated-string",
+  "cosmosDbName": "generated-string",
+  "location": "eastus",
   "kind": "DocumentDB"
 }

--- a/examples/documentdb-example-config.json
+++ b/examples/documentdb-example-config.json
@@ -8,8 +8,8 @@
 */
 // Please delete all the comments before using this .json to create service instance.
 {
-  "resourceGroup": "my-resource-group-name",
-  "docDbAccountName": "docdbaccount123",
-  "docDbName": "docdb123",
-  "location": "westus"
+  "resourceGroup": "azure-service-broker",
+  "docDbAccountName": "generated-string",
+  "docDbName": "generated-string",
+  "location": "eastus"
 }

--- a/examples/mysqldb-example-config.json
+++ b/examples/mysqldb-example-config.json
@@ -29,13 +29,13 @@
 
 // Please delete all the comments before using this .json to create service instance.
 {
-    "resourceGroup": "mysqldbResourceGroup",
-    "location": "westus",
-    "mysqlServerName": "mysqlservera",
+    "resourceGroup": "azure-service-broker",
+    "location": "eastus",
+    "mysqlServerName": "generated-string",
     "mysqlServerParameters": {
         "allowMysqlServerFirewallRules": [
             {
-              "ruleName": "newrule",
+              "ruleName": "all",
               "startIpAddress": "0.0.0.0",
               "endIpAddress": "255.255.255.255"
             }
@@ -44,8 +44,8 @@
             "version": "5.6",
             "sslEnforcement": "Disabled",
             "storageMB": 51200,
-            "administratorLogin": "myusername",
-            "administratorLoginPassword": "myPASSw0rd"
+            "administratorLogin": "generated-string",
+            "administratorLoginPassword": "generated-string"
         }
     }
 }

--- a/examples/postgresqldb-example-config.json
+++ b/examples/postgresqldb-example-config.json
@@ -29,13 +29,13 @@
 
 // Please delete all the comments before using this .json to create service instance.
 {
-    "resourceGroup": "postgresqldbResourceGroup",
-    "location": "westus",
-    "postgresqlServerName": "postgresqlservera",
+    "resourceGroup": "azure-service-broker",
+    "location": "eastus",
+    "postgresqlServerName": "generated-string",
     "postgresqlServerParameters": {
         "allowPostgresqlServerFirewallRules": [
             {
-              "ruleName": "newrule",
+              "ruleName": "all",
               "startIpAddress": "0.0.0.0",
               "endIpAddress": "255.255.255.255"
             }
@@ -44,8 +44,8 @@
             "version": "9.6",
             "sslEnforcement": "Disabled",
             "storageMB": 51200,
-            "administratorLogin": "myusername",
-            "administratorLoginPassword": "myPASSw0rd"
+            "administratorLogin": "generated-string",
+            "administratorLoginPassword": "generated-string"
         }
     }
 }

--- a/examples/rediscache-example-config.json
+++ b/examples/rediscache-example-config.json
@@ -1,9 +1,9 @@
 /*
 {
   "resourceGroup": "<resource-group-name>", // [Required] Unique. Only allow up to 90 characters
+  "location": "<location>",               // [Required  e.g. eastasia, eastus2, westus, etc. You can use azure cli command 'azure location list' to list all locations.
   "cacheName": "<cache-name>",              // [Required] Unique. Must be between 3 and 63 characters long. Can only contain numbers, letters, and the - character. The cache name cannot start or end with the - character, and consecutive - characters are not valid.
   "parameters": {
-    "location": "<location>",               // [Required  e.g. eastasia, eastus2, westus, etc. You can use azure cli command 'azure location list' to list all locations.
     "enableNonSslPort": true | false,
     "sku": {                                // [Required] e.g. Basic C 0 for cache size 250MB, low network performance and 256 client connections. See more skus: https://azure.microsoft.com/en-us/pricing/details/cache/
       "name": "<sku-name>",
@@ -15,10 +15,10 @@
 */
 // Please delete all the comments before using this .json to create service instance.
 {
-  "resourceGroup": "redisResourceGroup",
-  "cacheName": "mycache",
+  "resourceGroup": "azure-service-broker",
+  "location": "eastus",
+  "cacheName": "generated-string",
   "parameters": {
-    "location": "eastus",
     "enableNonSslPort": false,
     "sku": {
       "name": "Basic",

--- a/examples/servicebus-example-config.json
+++ b/examples/servicebus-example-config.json
@@ -1,17 +1,17 @@
  /*
 {
-  "resource_group_name": "<resource-group-name>", // [Required] Only allow up to 90 characters
-  "namespace_name": "<namespace-name>", // [Required] Between 6 and 50 characters long
-  "location": "<location>",             // [Required] e.g. eastasia, eastus2, westus, etc. You can use azure cli command 'azure location list' to list all locations.
-  "type": "<type>",                     // [Required] Possible values are `Messaging`, `EventHub` and `NotificationHub`
-  "messaging_tier": "<messaging-tier>"  // [Required] Possible values are `Basic`, `Standard` and `Premium` for type `Messaging`, `Basic` and `Standard` for type `EventHub`, `Standard` for type `NotificationHub`.
+  "resourceGroup": "<resource-group-name>", // [Required] Only allow up to 90 characters
+  "namespaceName": "<namespace-name>",      // [Required] Between 6 and 50 characters long
+  "location": "<location>",                 // [Required] e.g. eastasia, eastus2, westus, etc. You can use azure cli command 'azure location list' to list all locations.
+  "type": "<type>",                         // [Required] Possible values are `Messaging`, `EventHub` and `NotificationHub`
+  "messagingTier": "<messaging-tier>"       // [Required] Possible values are `Basic`, `Standard` and `Premium` for type `Messaging`, `Basic` and `Standard` for type `EventHub`, `Standard` for type `NotificationHub`.
 }
 */
 // Please delete all the comments before using this .json to create service instance.
 {
-  "resource_group_name": "example-servicebus",
-  "namespace_name": "example-servicebus",
-  "location": "westus",
+  "resourceGroup": "azure-service-broker",
+  "namespaceName": "generated-string",
+  "location": "eastus",
   "type": "Messaging",
-  "messaging_tier": "Standard"
+  "messagingTier": "Standard"
 }

--- a/examples/sqldb-example-config-for-server-exists.json
+++ b/examples/sqldb-example-config-for-server-exists.json
@@ -14,7 +14,7 @@
 // Please delete all the comments before using this .json to create service instance.
 {
     "sqlServerName": "sqlservera",
-    "sqldbName": "sqlDbA",
+    "sqldbName": "generated-string",
     "transparentDataEncryption": true,
     "sqldbParameters": {
         "properties": {

--- a/examples/sqldb-example-config.json
+++ b/examples/sqldb-example-config.json
@@ -33,23 +33,23 @@
 
 // Please delete all the comments before using this .json to create service instance.
 {
-    "resourceGroup": "sqldbResourceGroup",
-    "location": "westus",
-    "sqlServerName": "sqlservera",
+    "resourceGroup": "azure-service-broker",
+    "location": "eastus",
+    "sqlServerName": "generated-string",
     "sqlServerParameters": {
         "allowSqlServerFirewallRules": [
             {
-            "ruleName": "new rule",
-            "startIpAddress": "131.107.159.102",
-            "endIpAddress": "131.107.159.102"
+                "ruleName": "all",
+                "startIpAddress": "0.0.0.0",
+                "endIpAddress": "255.255.255.255"
             }
         ],
         "properties": {
-            "administratorLogin": "myusername",
-            "administratorLoginPassword": "mypassword"
+            "administratorLogin": "generated-string",
+            "administratorLoginPassword": "generated-string"
         }
     },
-    "sqldbName": "sqlDbA",
+    "sqldbName": "generated-string",
     "transparentDataEncryption": true,
     "sqldbParameters": {
         "properties": {

--- a/examples/storage-example-config.json
+++ b/examples/storage-example-config.json
@@ -1,15 +1,15 @@
  /*
 {
-  "resource_group_name": "<resource-group-name>",   // [Required] Unique. Only allow up to 90 characters
-  "storage_account_name": "<storage-account-name>", // [Required] Unique. Can contain only lowercase letters and numbers. Name must be between 3 and 24 characters.
-  "location": "<location>",                         // [Required] e.g. eastasia, eastus2, westus, etc. You can use azure cli command 'azure location list' to list all locations.
-  "account_type": "Standard_LRS | <other-account-type>"  // [Required] Possible value: Standard_LRS | Standard_ZRS | Standard_GRS | Standard_RAGRS | Premium_LRS . See more details: https://azure.microsoft.com/en-us/pricing/details/storage/
+  "resourceGroup": "<resource-group-name>",             // [Required] Unique. Only allow up to 90 characters
+  "location": "<location>",                             // [Required] e.g. eastasia, eastus2, westus, etc. You can use azure cli command 'azure location list' to list all locations.
+  "storageAccountName": "<storage-account-name>",       // [Required] Unique. Can contain only lowercase letters and numbers. Name must be between 3 and 24 characters.
+  "accountType": "Standard_LRS | <other-account-type>"  // [Required] Possible value: Standard_LRS | Standard_ZRS | Standard_GRS | Standard_RAGRS | Premium_LRS . See more details: https://azure.microsoft.com/en-us/pricing/details/storage/
 }
 */
 // Please delete all the comments before using this .json to create service instance.
 {
-  "resource_group_name": "myResourceGroup",
-  "storage_account_name": "mystorageaccount",
+  "resourceGroup": "azure-service-broker",
   "location": "eastus",
-  "account_type": "Standard_LRS"
+  "storageAccountName": "generated-string",
+  "accountType": "Standard_LRS"
 }

--- a/lib/broker/v2/api-handlers.js
+++ b/lib/broker/v2/api-handlers.js
@@ -91,7 +91,7 @@ Handlers.handleCatalogRequest = function(broker, req, res, next) {
 Handlers.handleProvisionRequest = function(broker, req, res, next) {
   var instanceId = req.params.instance_id;
   log.info('handleProvisionRequest - (instanceId: %s) from %s:%s', instanceId, req.connection.remoteAddress, req.connection.remotePort);
-
+  
   // Check whether the request is asynchronous.
   var accepts_incomplete = req.params.accepts_incomplete;
   if (typeof(accepts_incomplete) == 'undefined' || accepts_incomplete == 'false') {
@@ -104,7 +104,13 @@ Handlers.handleProvisionRequest = function(broker, req, res, next) {
     res.send(HttpStatus.UNPROCESSABLE_ENTITY, body);
     return next();
   }
-
+  
+  // The req.params.parameters doesn't exist if "cf create-service" doesn't pass parameter in with "-c"
+  if (_.isUndefined(req.params.parameters)) req.params.parameters = {};
+  
+  req.params.parameters = global.modules[req.params.service_id].fixParameters(req.params.parameters, accountPool);
+  log.info('handleProvisionRequest - (instanceId: %s) - fixed parameters: %j', instanceId, req.params.parameters);
+  
   // Generate Azure instance id from the matched service module
   // Format: [SERVICE-MODULE-NAME]-[UNIQUE-SERVICE-INSTANCE-NAME]
   var azureInstanceId = global.modules[req.params.service_id].generateAzureInstanceId(req.params);
@@ -426,7 +432,7 @@ Handlers.handleBindRequest = function(broker, req, res, next) {
       log.info('handleBindRequest - Succeeded in sending the bind error response (bindingId: %s) for (instanceId: %s) to cc.', bindingId, instanceId);
       return next();
     }
-
+    
     broker.db.createServiceBinding(req.params, result, function(err){
       if (err) {
         log.error('handleBindRequest - %j', err);

--- a/lib/common/index.js
+++ b/lib/common/index.js
@@ -29,6 +29,7 @@ var util = require('util');
 var S = require('string');
 var HttpStatus = require('http-status-codes');
 var AzureEnvironment = require('ms-rest-azure').AzureEnvironment;
+var deepExtend = require('deep-extend');
 
 var validateConfigurations = function() {
   var requiredEnvNames = [
@@ -77,6 +78,27 @@ var validateConfigurations = function() {
       });
     });
   }
+  
+  // validate JSON type in default parameters
+  var envVarShouldBeJSON = [
+    'DEFAULT_PARAMETERS_AZURE_REDISCACHE',
+    'DEFAULT_PARAMETERS_AZURE_SERVICEBUS',
+    'DEFAULT_PARAMETERS_AZURE_STORAGE',
+    'DEFAULT_PARAMETERS_AZURE_COSMOSDB',
+    'DEFAULT_PARAMETERS_AZURE_MYSQLDB',
+    'DEFAULT_PARAMETERS_AZURE_POSTGRESQLDB',
+    'DEFAULT_PARAMETERS_AZURE_SQLDB'
+  ];
+  envVarShouldBeJSON.forEach(function(envVarName) {
+    if (process.env[envVarName]) {
+      try {
+        JSON.parse(process.env[envVarName]);
+      } catch (ex) {
+        log.error('error in parsing %s', envVarName);
+        throw ex;
+      }
+    }
+  });
 };
 
 module.exports.getConfigurations = function() {
@@ -185,6 +207,81 @@ module.exports.API_VERSION = {
     COSMOSDB: '2015-04-08'
   }
 };
+
+module.exports.fixParametersWithDefaults = function (envVarName, parameters) {
+  if (process.env[envVarName]) {
+    var defaultParams = JSON.parse(process.env[envVarName]);
+    // The right overwrites the left if conflict
+    parameters = deepExtend(defaultParams, parameters);
+  }
+    
+  var defaultResourceGroup = process.env['DEFAULT_RESOURCE_GROUP'];
+  if (defaultResourceGroup) {
+    if (_.isUndefined(parameters.resourceGroup)) {
+      parameters.resourceGroup = defaultResourceGroup;
+    }
+  }
+  var defaultLocation  = process.env['DEFAULT_LOCATION'];
+  if (defaultLocation) {
+    if (_.isUndefined(parameters.location)) {
+      parameters.location = defaultLocation;
+    }
+  }
+  
+  return parameters;
+};
+
+module.exports.generateName = function (length) {
+  var usernameLength = length;
+  if (!usernameLength) usernameLength = 12;
+  return 'u' + uuid.v4().replace(/-/g, '').slice(0,usernameLength - 1);
+};
+
+module.exports.generateStrongPassword = function (length) {
+  
+  var uppercaseLetters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
+  var lowercaseLetters = uppercaseLetters.toLowerCase();
+  var numbers = '1234567890';
+                
+  var passwordLength = length;
+  if (!passwordLength) passwordLength = 12;
+  if (passwordLength < 8) {
+    throw Error('Length is too short for a strong password.');
+  }
+                
+  function getRandomInt (min, max) {
+    return Math.floor(Math.random() * (max - min + 1)) + min;
+  }
+
+  // Fisher–Yates Shuffle
+  Array.prototype.shuffle = function() {
+    for (var i = this.length - 1; i > 0; i--) {
+      var j = Math.floor(Math.random() * (i + 1));
+      var temp = this[i];
+      this[i] = this[j];
+      this[j] = temp;
+    }
+    return this;
+  };
+                
+  var pwd = '';
+  
+  var upperLength = getRandomInt(1, passwordLength-2);
+  pwd += _.sample(uppercaseLetters, upperLength).join('');
+                
+  var lowerLength = getRandomInt(1, passwordLength-upperLength-1);
+  pwd +=  _.sample(lowercaseLetters, lowerLength).join('');
+                
+  var numLength = passwordLength - upperLength - lowerLength;
+  pwd +=  _.sample(numbers, numLength).join('');
+                
+  pwd = pwd.split('')
+           .shuffle()
+           .join('');
+  
+  return pwd;
+};
+
 
 module.exports.logHttpResponse = function (res, operation, logBody) {
   if (!(log && res)) return;

--- a/lib/services/azurecosmosdb/cmd-poll.js
+++ b/lib/services/azurecosmosdb/cmd-poll.js
@@ -18,7 +18,7 @@ var cosmosDbPoll = function(params) {
   
   var reqParams = params.parameters || {};
   var cosmosDbName = reqParams.cosmosDbName || '';
-
+  
   function sendReply(reply, callback){
     reply = {
       statusCode: HttpStatus.OK,

--- a/lib/services/azurecosmosdb/index.js
+++ b/lib/services/azurecosmosdb/index.js
@@ -21,6 +21,15 @@ var util = require('util');
 
 var Handlers = {};
 
+Handlers.fixParameters = function(parameters) {
+  parameters = common.fixParametersWithDefaults('DEFAULT_PARAMETERS_AZURE_COSMOSDB', parameters);
+  if (process.env['ALLOW_TO_GENERATE_NAMES_AND_PASSWORDS_FOR_THE_MISSING'] === 'true') {
+    if (!parameters.cosmosDbAccountName) parameters.cosmosDbAccountName = common.generateName();
+    if (!parameters.cosmosDbName) parameters.cosmosDbName = common.generateName();
+  }
+  return parameters;
+};
+
 Handlers.catalog = function(params, next) {
   var reply = Config;
   next(null, reply);
@@ -33,7 +42,7 @@ Handlers.generateAzureInstanceId = function(params) {
 Handlers.provision = function(params, next) {
 
   log.debug('CosmosDb/index/provision/params: %j', params);
-
+  
   var cp = new cmdProvision(params);
   var reqParams = params.parameters;
   

--- a/lib/services/azuredocdb/index.js
+++ b/lib/services/azuredocdb/index.js
@@ -20,6 +20,15 @@ var Reply = require('../../common/reply');
 
 var Handlers = {};
 
+Handlers.fixParameters = function(parameters) {
+  parameters = common.fixParametersWithDefaults('DEFAULT_PARAMETERS_AZURE_DOCDB', parameters);
+  if (process.env['ALLOW_TO_GENERATE_NAMES_AND_PASSWORDS_FOR_THE_MISSING'] === 'true') {
+    if (!parameters.docDbAccountName) parameters.docDbAccountName = common.generateName();
+    if (!parameters.docDbName) parameters.docDbName = common.generateName();
+  }
+  return parameters;
+};
+
 Handlers.catalog = function(params, next) {
   var reply = Config;
   next(null, reply);

--- a/lib/services/azuremysqldb/cmd-provision.js
+++ b/lib/services/azuremysqldb/cmd-provision.js
@@ -14,7 +14,6 @@ var mysqldbProvision = function (params) {
     var reqParams = params.parameters || {};
     var mysqlServerName = reqParams.mysqlServerName || '';
     
-    // read resourceGroupName, location, administratorLogin, administratorLoginPassword all from module config, or all from broker config
     var resourceGroupName = reqParams.resourceGroup || '';
     var location = reqParams.location || '';
     

--- a/lib/services/azuremysqldb/index.js
+++ b/lib/services/azuremysqldb/index.js
@@ -15,13 +15,28 @@ var mysqldbOperations = require('./client');
 
 var Handlers = {};
 
-Handlers.generateAzureInstanceId = function(params) {
-  return Config.name + '-' + params.parameters['mysqlServerName'];
+Handlers.fixParameters = function(parameters) {
+  parameters = common.fixParametersWithDefaults('DEFAULT_PARAMETERS_AZURE_MYSQLDB', parameters);
+  if (process.env['ALLOW_TO_GENERATE_NAMES_AND_PASSWORDS_FOR_THE_MISSING'] === 'true') {
+    if (!parameters.mysqlServerName) parameters.mysqlServerName = common.generateName();
+    
+    if (!parameters.mysqlServerParameters) parameters.mysqlServerParameters = {};
+    var serverParams = parameters.mysqlServerParameters;
+    if (!serverParams.properties) serverParams.properties = {};
+    var serverProps = serverParams.properties;
+    if (!serverProps.administratorLogin) serverProps.administratorLogin = common.generateName();
+    if (!serverProps.administratorLoginPassword) serverProps.administratorLoginPassword = common.generateStrongPassword();
+  }
+  return parameters;
 };
 
 Handlers.catalog = function (params, next) {
   var reply = Config;
   next(null, reply);
+};
+
+Handlers.generateAzureInstanceId = function(params) {
+  return Config.name + '-' + params.parameters['mysqlServerName'];
 };
 
 Handlers.provision = function (params, next) {
@@ -97,8 +112,12 @@ Handlers.bind = function (params, next) {
   log.debug('mysqldb/index/bind/params: %j', params);
 
   var provisioningResult = params.provisioning_result;
-      
+  
+  var mysqlServerName = provisioningResult.mysqlServerName;
+  var administratorLogin = provisioningResult.administratorLogin;
+  var administratorLoginPassword = provisioningResult.administratorLoginPassword;
   var fqdn = provisioningResult.fullyQualifiedDomainName;
+  
   // Spring Cloud Connector Support
   var jdbcUrlTemplate = 'jdbc:mysql://%s:3306' + 
                         '/{your_database}' + 
@@ -108,17 +127,17 @@ Handlers.bind = function (params, next) {
       
   var jdbcUrl = util.format(jdbcUrlTemplate,
                             fqdn);
-                      
+
   // contents of reply.value winds up in VCAP_SERVICES
   var reply = {
     statusCode: HttpStatus.CREATED,
     code: HttpStatus.getStatusText(HttpStatus.CREATED),
     value: {
       credentials: {
-        mysqlServerName: provisioningResult.mysqlServerName,
+        mysqlServerName: mysqlServerName,
         mysqlServerFullyQualifiedDomainName: fqdn,
-        administratorLogin: provisioningResult.administratorLogin,
-        administratorLoginPassword: provisioningResult.administratorLoginPassword,
+        administratorLogin: administratorLogin,
+        administratorLoginPassword: administratorLoginPassword,
         jdbcUrl: jdbcUrl
       }
     }

--- a/lib/services/azurepostgresqldb/cmd-provision.js
+++ b/lib/services/azurepostgresqldb/cmd-provision.js
@@ -14,7 +14,6 @@ var postgresqldbProvision = function (params) {
     var reqParams = params.parameters || {};
     var postgresqlServerName = reqParams.postgresqlServerName || '';
     
-    // read resourceGroupName, location, administratorLogin, administratorLoginPassword all from module config, or all from broker config
     var resourceGroupName = reqParams.resourceGroup || '';
     var location = reqParams.location || '';
     

--- a/lib/services/azurepostgresqldb/index.js
+++ b/lib/services/azurepostgresqldb/index.js
@@ -15,13 +15,28 @@ var postgresqldbOperations = require('./client');
 
 var Handlers = {};
 
-Handlers.generateAzureInstanceId = function(params) {
-  return Config.name + '-' + params.parameters['postgresqlServerName'];
+Handlers.fixParameters = function(parameters) {
+  parameters = common.fixParametersWithDefaults('DEFAULT_PARAMETERS_AZURE_POSTGRESQLDB', parameters);
+  if (process.env['ALLOW_TO_GENERATE_NAMES_AND_PASSWORDS_FOR_THE_MISSING'] === 'true') {
+    if (!parameters.postgresqlServerName) parameters.postgresqlServerName = common.generateName();
+    
+    if (!parameters.postgresqlServerParameters) parameters.postgresqlServerParameters = {};
+    var serverParams = parameters.postgresqlServerParameters;
+    if (!serverParams.properties) serverParams.properties = {};
+    var serverProps = serverParams.properties;
+    if (!serverProps.administratorLogin) serverProps.administratorLogin = common.generateName();
+    if (!serverProps.administratorLoginPassword) serverProps.administratorLoginPassword = common.generateStrongPassword();
+  }
+  return parameters;
 };
 
 Handlers.catalog = function (params, next) {
   var reply = Config;
   next(null, reply);
+};
+
+Handlers.generateAzureInstanceId = function(params) {
+  return Config.name + '-' + params.parameters['postgresqlServerName'];
 };
 
 Handlers.provision = function (params, next) {
@@ -97,8 +112,12 @@ Handlers.bind = function (params, next) {
   log.debug('postgresqldb/index/bind/params: %j', params);
 
   var provisioningResult = params.provisioning_result;
-      
+  
+  var postgresqlServerName = provisioningResult.postgresqlServerName;
+  var administratorLogin = provisioningResult.administratorLogin;
+  var administratorLoginPassword = provisioningResult.administratorLoginPassword;
   var fqdn = provisioningResult.fullyQualifiedDomainName;
+  
   // Spring Cloud Connector Support
   var jdbcUrlTemplate = 'jdbc:postgresql://%s:5432' + 
                         '/{your_database}' +
@@ -107,9 +126,9 @@ Handlers.bind = function (params, next) {
                         '&ssl=true';
   var jdbcUrl = util.format(jdbcUrlTemplate,
                             fqdn,
-                            provisioningResult.administratorLogin,
-                            provisioningResult.postgresqlServerName,
-                            provisioningResult.administratorLoginPassword);
+                            administratorLogin,
+                            postgresqlServerName,
+                            administratorLoginPassword);
                       
   // contents of reply.value winds up in VCAP_SERVICES
   var reply = {
@@ -117,10 +136,10 @@ Handlers.bind = function (params, next) {
     code: HttpStatus.getStatusText(HttpStatus.CREATED),
     value: {
       credentials: {
-        postgresqlServerName: provisioningResult.postgresqlServerName,
+        postgresqlServerName: postgresqlServerName,
         postgresqlServerFullyQualifiedDomainName: fqdn,
-        administratorLogin: provisioningResult.administratorLogin,
-        administratorLoginPassword: provisioningResult.administratorLoginPassword,
+        administratorLogin: administratorLogin,
+        administratorLoginPassword: administratorLoginPassword,
         jdbcUrl: jdbcUrl
       }
     }

--- a/lib/services/azurerediscache/cmd-provision.js
+++ b/lib/services/azurerediscache/cmd-provision.js
@@ -15,14 +15,8 @@ var cacheProvision = function(params) {
 
   var resourceGroupName = reqParams.resourceGroup || '';
   var cacheName = reqParams.cacheName || '';
-
-  var parametersDefined = !(_.isNull(reqParams.parameters) || _.isUndefined(reqParams.parameters));
-
-  var location = '';
-  if (parametersDefined) {
-    location = reqParams.parameters.location || '';
-  }
-
+  var location = reqParams.location;
+  
   this.provision = function(redis, next) {
       
     var groupParameters = {
@@ -34,10 +28,10 @@ var cacheProvision = function(params) {
           resourceGroup.createOrUpdate('Redis Cache', params.azure, resourceGroupName, groupParameters, callback);
       },
       function(callback) {
-        log.debug('Redis Cache, redis.provision, resourceGroupName: %j', resourceGroupName);
-        log.debug('Redis Cache, redis.provision, cacheName: %j', cacheName);
+        log.debug('Redis Cache, redis.provision, resourceGroupName: %s, cacheName: %s', resourceGroupName, cacheName);
         var redisParams = reqParams.parameters;
         redisParams.tags = common.mergeTags(redisParams.tags);
+        redisParams.location = location;
         log.debug('Redis Cache, redis.provision, reqParams.parameters: %j', redisParams);
         redis.provision(resourceGroupName, cacheName, redisParams, function(err, result) {
           if (err) {

--- a/lib/services/azurerediscache/index.js
+++ b/lib/services/azurerediscache/index.js
@@ -16,6 +16,14 @@ var Reply = require('../../common/reply');
 
 var Handlers = {};
 
+Handlers.fixParameters = function(parameters) {
+  parameters = common.fixParametersWithDefaults('DEFAULT_PARAMETERS_AZURE_REDISCACHE', parameters);
+  if (process.env['ALLOW_TO_GENERATE_NAMES_AND_PASSWORDS_FOR_THE_MISSING'] === 'true') {
+    if (!parameters.cacheName) parameters.cacheName = common.generateName();
+  }
+  return parameters;
+};
+
 Handlers.catalog = function (params, next) {
   var reply = Config;
   next(null, reply);
@@ -28,7 +36,7 @@ Handlers.generateAzureInstanceId = function(params) {
 Handlers.provision = function (params, next) {
 
   log.debug('Redis Cache/index/provision/params: %j', params);
-
+  
   var cp = new cmdProvision(params);
   if (!cp.allValidatorsSucceed()) {
     return common.handleServiceErrorEx(HttpStatus.BAD_REQUEST, 'Parameter validation failed. Did you supply a redis cache parameters file?', next);

--- a/lib/services/azureservicebus/index.js
+++ b/lib/services/azureservicebus/index.js
@@ -12,8 +12,30 @@ var log = common.getLogger(config.name);
 
 var Handlers = {};
 
+Handlers.fixParameters = function(parameters) {
+  // translate deprecated format
+  if (parameters['resource_group_name']) {
+    parameters['resourceGroup'] = parameters['resource_group_name'];
+    delete parameters['resource_group_name'];
+  }
+  if (parameters['namespace_name']) {
+    parameters['namespaceName'] = parameters['namespace_name'];
+    delete parameters['namespace_name'];
+  }
+  if (parameters['messaging_tier']) {
+    parameters['messagingTier'] = parameters['messaging_tier'];
+    delete parameters['messaging_tier'];
+  }
+  
+  parameters = common.fixParametersWithDefaults('DEFAULT_PARAMETERS_AZURE_SERVICEBUS', parameters);
+  if (process.env['ALLOW_TO_GENERATE_NAMES_AND_PASSWORDS_FOR_THE_MISSING'] === 'true') {
+    if (!parameters.namespaceName) parameters.namespaceName = common.generateName();
+  }
+  return parameters;
+};
+
 Handlers.generateAzureInstanceId = function(params) {
-  return config.name + '-' + params.parameters['namespace_name'];
+  return config.name + '-' + params.parameters['namespaceName'];
 };
 
 Handlers.catalog = function(params, next) {
@@ -27,11 +49,11 @@ Handlers.provision = function(params, next) {
   log.debug('Provision params: %j', params);
 
   var reqParams = params.parameters || {};
-
-  var reqParamsKey = ['resource_group_name', 'namespace_name', 'location', 'type', 'messaging_tier'];
+  
+  var reqParamsKey = ['resourceGroup', 'namespaceName', 'location', 'type', 'messagingTier'];
   var errMsg = common.verifyParameters(reqParams, reqParamsKey);
   if (errMsg) {
-    return common.handleServiceErrorEx(HttpStatus.BAD_REQUEST, errMsg, next);
+      return common.handleServiceErrorEx(HttpStatus.BAD_REQUEST, errMsg, next);
   }
 
   var azure_config = {

--- a/lib/services/azuresqldb/cmd-bind.js
+++ b/lib/services/azuresqldb/cmd-bind.js
@@ -1,7 +1,6 @@
 /* jshint camelcase: false */
 /* jshint newcap: false */
 
-var _ = require('underscore');
 var async = require('async');
 var util = require('util');
 var Config = require('./service');
@@ -26,45 +25,9 @@ var sqldbBind = function (params) {
         
         async.waterfall([
             function (callback) {
+                databaseLogin = common.generateName();
+                databaseLoginPassword = common.generateStrongPassword();
                 
-                // generate database login
-                var uppercaseLetters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
-                var lowercaseLetters = uppercaseLetters.toLowerCase();
-                var numbers = '1234567890';
-                
-                databaseLogin = _.sample(uppercaseLetters + lowercaseLetters + numbers, 10).join('');
-                
-                // generate database login password
-                var passwordLength = 10;
-                
-                function getRandomInt (min, max) {
-                    return Math.floor(Math.random() * (max - min + 1)) + min;
-                }
-
-                Array.prototype.shuffle = function() {
-                    for (var i = this.length - 1; i > 0; i--) {
-                        var j = Math.floor(Math.random() * (i + 1));
-                        var temp = this[i];
-                        this[i] = this[j];
-                        this[j] = temp;
-                    }
-                    return this;
-                };
-                
-                databaseLoginPassword = '';
-                
-                var upperLength = getRandomInt(1, passwordLength-2);
-                databaseLoginPassword += _.sample(uppercaseLetters, upperLength).join('');
-                
-                var lowerLength = getRandomInt(1, passwordLength-upperLength-1);
-                databaseLoginPassword +=  _.sample(lowercaseLetters, lowerLength).join('');
-                
-                var numLength = passwordLength - upperLength - lowerLength;
-                databaseLoginPassword +=  _.sample(numbers, numLength).join('');
-                
-                databaseLoginPassword = databaseLoginPassword.split('')
-                                                             .shuffle()
-                                                             .join('');
                 // create the login
                 sqldbOperations.createDatabaseLogin(
                     provisioningResult.fullyQualifiedDomainName,

--- a/lib/services/azuresqldb/index.js
+++ b/lib/services/azuresqldb/index.js
@@ -15,8 +15,48 @@ var cmdBind = require('./cmd-bind.js');
 var cmdUnbind = require('./cmd-unbind.js');
 var cmdUpdate = require('./cmd-update.js');
 var sqldbOperations = require('./client');
+var deepExtend = require('deep-extend');
 
 var Handlers = {};
+
+Handlers.fixParameters = function(parameters, accountPool) {
+  
+  if (parameters.sqlServerName && parameters.sqlServerName in accountPool.sqldb) { // assume user wants to create db on an existing server
+    if (process.env['DEFAULT_PARAMETERS_AZURE_SQLDB']) {
+      var defaultParams = JSON.parse(process.env['DEFAULT_PARAMETERS_AZURE_SQLDB']);
+      // For creating db on an existing server, following default parameters should be deleted. The broker gets these info in provision.
+      delete defaultParams.resourceGroup;
+      delete defaultParams.location;
+      delete defaultParams.sqlServerName;
+      delete defaultParams.sqlServerParameters;
+        
+      // The right overwrites the left if conflict
+      parameters = deepExtend(defaultParams, parameters);
+    }
+    
+    if (process.env['ALLOW_TO_GENERATE_NAMES_AND_PASSWORDS_FOR_THE_MISSING'] === 'true') {
+      if (!parameters.sqldbName) parameters.sqldbName = common.generateName();
+    }
+    
+    return parameters;
+    
+  } else {
+    parameters = common.fixParametersWithDefaults('DEFAULT_PARAMETERS_AZURE_SQLDB', parameters);
+    if (process.env['ALLOW_TO_GENERATE_NAMES_AND_PASSWORDS_FOR_THE_MISSING'] === 'true') {
+      if (!parameters.sqlServerName) parameters.sqlServerName = common.generateName();
+      if (!parameters.sqldbName) parameters.sqldbName = common.generateName();
+      
+      if (!parameters.sqlServerParameters) parameters.sqlServerParameters = {};
+      var serverParams = parameters.sqlServerParameters;
+      if (!serverParams.properties) serverParams.properties = {};
+      var serverProps = serverParams.properties;
+      if (!serverProps.administratorLogin) serverProps.administratorLogin = common.generateName();
+      if (!serverProps.administratorLoginPassword) serverProps.administratorLoginPassword = common.generateStrongPassword();
+    }
+    
+    return parameters;
+  }
+};
 
 Handlers.generateAzureInstanceId = function(params) {
   return Config.name + '-' + params.parameters['sqlServerName'] + '-' + params.parameters['sqldbName'];
@@ -30,7 +70,7 @@ Handlers.catalog = function (params, next) {
 Handlers.provision = function (params, next) {
 
   log.debug('SqlDb/index/provision/params: %j', params);
-
+  
   var cp = new cmdProvision(params);
   log.info('sqldb index: cmdProvision is newed up');
 
@@ -166,7 +206,7 @@ Handlers.unbind = function (params, next) {
   var cp = new cmdUnbind(params);
   var sqldbOps = new sqldbOperations(params.azure);
 
-  cp.unbind(sqldbOps, function (err, result) {
+  cp.unbind(sqldbOps, function (err) {
     if (err) {
       return common.handleServiceError(err, next);
     }

--- a/lib/services/azurestorage/index.js
+++ b/lib/services/azurestorage/index.js
@@ -11,8 +11,30 @@ var log = common.getLogger(config.name);
 
 var Handlers = {};
 
+Handlers.fixParameters = function(parameters) {
+  // translate deprecated format
+  if (parameters['resource_group_name']) {
+    parameters['resourceGroup'] = parameters['resource_group_name'];
+    delete parameters['resource_group_name'];
+  }
+  if (parameters['storage_account_name']) {
+    parameters['storageAccountName'] = parameters['storage_account_name'];
+    delete parameters['storage_account_name'];
+  }
+  if (parameters['account_type']) {
+    parameters['accountType'] = parameters['account_type'];
+    delete parameters['account_type'];
+  }
+  
+  parameters = common.fixParametersWithDefaults('DEFAULT_PARAMETERS_AZURE_STORAGE', parameters);
+  if (process.env['ALLOW_TO_GENERATE_NAMES_AND_PASSWORDS_FOR_THE_MISSING'] === 'true') {
+    if (!parameters.storageAccountName) parameters.storageAccountName = common.generateName();
+  }
+  return parameters;
+};
+
 Handlers.generateAzureInstanceId = function(params) {
-  return config.name + '-' + params.parameters['storage_account_name'];
+  return config.name + '-' + params.parameters['storageAccountName'];
 };
 
 Handlers.catalog = function(params, next) {
@@ -27,7 +49,7 @@ Handlers.provision = function(params, next) {
 
   var reqParams = params.parameters || {};
   
-  var reqParamsKey = ['resource_group_name', 'storage_account_name', 'location', 'account_type'];
+  var reqParamsKey = ['resourceGroup', 'storageAccountName', 'location', 'accountType'];
   var errMsg = common.verifyParameters(reqParams, reqParamsKey);
   if (errMsg) {
     return common.handleServiceErrorEx(HttpStatus.BAD_REQUEST, errMsg, next);

--- a/manifest.yml
+++ b/manifest.yml
@@ -36,3 +36,80 @@ applications:
         "administratorLoginPassword": "REPLACE-ME"
       }
     ]'
+    
+    ALLOW_TO_GENERATE_NAMES_AND_PASSWORDS_FOR_THE_MISSING: true
+    
+    DEFAULT_RESOURCE_GROUP: azure-service-broker
+    DEFAULT_LOCATION: eastus
+    
+    DEFAULT_PARAMETERS_AZURE_REDISCACHE: '{
+        "parameters": {
+            "enableNonSslPort": false,
+            "sku": {
+                "name": "Basic",
+                "family": "C",
+                "capacity": 0
+            }
+        }
+    }'
+    DEFAULT_PARAMETERS_AZURE_SERVICEBUS: '{
+        "type": "Messaging",
+        "messagingTier": "Standard"
+    }'
+    DEFAULT_PARAMETERS_AZURE_STORAGE: '{
+        "accountType": "Standard_LRS"
+    }'
+    DEFAULT_PARAMETERS_AZURE_DOCDB: '{
+    }'
+    DEFAULT_PARAMETERS_AZURE_COSMOSDB: '{
+        "kind": "DocumentDB"
+    }'
+    DEFAULT_PARAMETERS_AZURE_MYSQLDB: '{
+        "mysqlServerParameters": {
+            "allowMysqlServerFirewallRules": [
+                {
+                  "ruleName": "all",
+                  "startIpAddress": "0.0.0.0",
+                  "endIpAddress": "255.255.255.255"
+                }
+            ],
+            "properties": {
+                "version": "5.6",
+                "sslEnforcement": "Disabled",
+                "storageMB": 51200
+            }
+        }
+    }'
+    DEFAULT_PARAMETERS_AZURE_POSTGRESQLDB: '{
+        "postgresqlServerParameters": {
+            "allowPostgresqlServerFirewallRules": [
+                {
+                  "ruleName": "all",
+                  "startIpAddress": "0.0.0.0",
+                  "endIpAddress": "255.255.255.255"
+                }
+            ],
+            "properties": {
+                "version": "9.6",
+                "sslEnforcement": "Disabled",
+                "storageMB": 51200
+            }
+        }
+    }'
+    DEFAULT_PARAMETERS_AZURE_SQLDB: '{
+        "sqlServerParameters": {
+            "allowSqlServerFirewallRules": [
+                {
+                    "ruleName": "all",
+                    "startIpAddress": "0.0.0.0",
+                    "endIpAddress": "255.255.255.255"
+                }
+            ]
+        },
+        "transparentDataEncryption": true,
+        "sqldbParameters": {
+            "properties": {
+                "collation": "SQL_Latin1_General_CP1_CI_AS"
+            }
+        }
+    }'

--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
     "ts-node": "^3.0.4",
     "typescript": "^2.3.2",
     "underscore": "1.8.3",
-    "uuid": "3.0.1"
+    "uuid": "3.0.1",
+    "deep-extend": "0.5.0"
   },
   "devDependencies": {
     "azure": "0.10.6",

--- a/test/integration/cleaner.js
+++ b/test/integration/cleaner.js
@@ -6,7 +6,7 @@ var should = chai.should();
 var util = require('util');
 
 exports.clean = function(provisioningParameters, done) {
-  var resourceGroupName = provisioningParameters.resourceGroup || provisioningParameters.resource_group_name;
+  var resourceGroupName = provisioningParameters.resourceGroup;
   if (!resourceGroupName) {
     return done();
   }

--- a/test/integration/submatrix/rediscache.js
+++ b/test/integration/submatrix/rediscache.js
@@ -20,7 +20,6 @@ instanceId = uuid.v4();
 bindingId = uuid.v4();
 resourceGroupName = 'cloud-foundry-' + instanceId;
 var cacheName = 'cf' + instanceId;
-var hostname = cacheName + supportedEnvironments[environment]['redisCacheEndpointSuffix'];
 var azurerediscache = {
   serviceName: 'azure-rediscache',
   serviceId: '0346088a-d4b2-4478-aa32-f18e295ec1d9',
@@ -29,9 +28,9 @@ var azurerediscache = {
   bindingId: bindingId,
   provisioningParameters: {
     'resourceGroup': resourceGroupName,
+    'location': location,
     'cacheName': cacheName,
     'parameters': {
-      'location': location,
       'enableNonSslPort': false,
       'sku': {
         'name': 'Basic',
@@ -45,7 +44,7 @@ var azurerediscache = {
   },
   bindingParameters: {},
   credentials: {
-    'hostname': hostname,
+    'hostname': '<string>',
     'name': cacheName,
     'port': 6379,
     'primaryKey': '<string>',

--- a/test/integration/submatrix/servicebus.js
+++ b/test/integration/submatrix/servicebus.js
@@ -27,11 +27,11 @@ var azureservicebus = {
   instanceId: instanceId,
   bindingId: bindingId,
   provisioningParameters: {
-    'resource_group_name': resourceGroupName,
-    'namespace_name': namespaceName,
+    'resourceGroup': resourceGroupName,
+    'namespaceName': namespaceName,
     'location': location,
     'type': 'Messaging',
-    'messaging_tier': 'Standard',
+    'messagingTier': 'Standard',
     'tags': {
       'foo': 'bar'
     }

--- a/test/integration/submatrix/storage.js
+++ b/test/integration/submatrix/storage.js
@@ -27,10 +27,10 @@ var azurestorage = {
   instanceId: instanceId,
   bindingId: bindingId,
   provisioningParameters: {
-    'resource_group_name': resourceGroupName,
-    'storage_account_name': storageAccountName,
+    'resourceGroup': resourceGroupName,
+    'storageAccountName': storageAccountName,
     'location': location,
-    'account_type': 'Standard_RAGRS',
+    'accountType': 'Standard_RAGRS',
     'tags': {
       'foo': 'bar'
     }

--- a/test/unit/services/azurecosmosdb/fixParameters-spec.js
+++ b/test/unit/services/azurecosmosdb/fixParameters-spec.js
@@ -1,0 +1,59 @@
+/* jshint camelcase: false */
+/* jshint newcap: false */
+/* global describe, before, it */
+
+var should = require('should');
+var azurecosmosdb = require('../../../../lib/services/azurecosmosdb/');
+
+describe('CosmosDB', function() {
+
+  describe('fixParameters', function() {
+    before(function() {
+      process.env['ALLOW_TO_GENERATE_NAMES_AND_PASSWORDS_FOR_THE_MISSING'] = 'true';
+      process.env['DEFAULT_RESOURCE_GROUP'] = 'azure-service-broker';
+      process.env['DEFAULT_LOCATION'] = 'eastus';
+      process.env['DEFAULT_PARAMETERS_AZURE_COSMOSDB'] = '{\
+        "kind": "DocumentDB"\
+      }';
+    });
+    
+    var paramsToValidate = ['resourceGroup', 'cosmosDbAccountName', 'location', 'cosmosDbName', 'kind'];
+      
+    describe('When no parameter passed in', function() {
+      var parameters = {};
+      
+      it('should fix the parameters', function() {
+        var fixedParams = azurecosmosdb.fixParameters(parameters);
+        paramsToValidate.forEach(function(param){
+          should.exist(fixedParams[param]);
+        });
+        fixedParams.location.should.equal('eastus');
+        fixedParams.cosmosDbAccountName.length.should.equal(12);
+      });
+    });
+
+    describe('When part of parameters passed in: kind', function() {
+      var parameters = {'kind': 'fake-kind'};
+      
+      it('should fix the parameters', function() {
+        var fixedParams = azurecosmosdb.fixParameters(parameters);
+        paramsToValidate.forEach(function(param){
+          should.exist(fixedParams[param]);
+        });
+        fixedParams.kind.should.equal('fake-kind');
+      });
+    });
+    
+    describe('When part of parameters passed in: cosmosDbAccountName', function() {
+      var parameters = {'cosmosDbAccountName': 'fake-name'};
+      
+      it('should fix the parameters', function() {
+        var fixedParams = azurecosmosdb.fixParameters(parameters);
+        paramsToValidate.forEach(function(param){
+          should.exist(fixedParams[param]);
+        });
+        fixedParams.cosmosDbAccountName.should.equal('fake-name');
+      });
+    });
+  });
+});

--- a/test/unit/services/azuredocdb/fixParameters-spec.js
+++ b/test/unit/services/azuredocdb/fixParameters-spec.js
@@ -1,0 +1,58 @@
+/* jshint camelcase: false */
+/* jshint newcap: false */
+/* global describe, before, it */
+
+var should = require('should');
+var azuredocdb = require('../../../../lib/services/azuredocdb/');
+
+describe('DocDB', function() {
+
+  describe('fixParameters', function() {
+    before(function() {
+      process.env['ALLOW_TO_GENERATE_NAMES_AND_PASSWORDS_FOR_THE_MISSING'] = 'true';
+      process.env['DEFAULT_RESOURCE_GROUP'] = 'azure-service-broker';
+      process.env['DEFAULT_LOCATION'] = 'eastus';
+      process.env['DEFAULT_PARAMETERS_AZURE_DOCDB'] = '{\
+      }';
+    });
+    
+    var paramsToValidate = ['resourceGroup', 'docDbAccountName', 'location', 'docDbName'];
+      
+    describe('When no parameter passed in', function() {
+      var parameters = {};
+      
+      it('should fix the parameters', function() {
+        var fixedParams = azuredocdb.fixParameters(parameters);
+        paramsToValidate.forEach(function(param){
+          should.exist(fixedParams[param]);
+        });
+        fixedParams.location.should.equal('eastus');
+        fixedParams.docDbAccountName.length.should.equal(12);
+      });
+    });
+
+    describe('When part of parameters passed in: location', function() {
+      var parameters = {'location': 'fake-location'};
+      
+      it('should fix the parameters', function() {
+        var fixedParams = azuredocdb.fixParameters(parameters);
+        paramsToValidate.forEach(function(param){
+          should.exist(fixedParams[param]);
+        });
+        fixedParams.location.should.equal('fake-location');
+      });
+    });
+    
+    describe('When part of parameters passed in: docDbAccountName', function() {
+      var parameters = {'docDbAccountName': 'fake-name'};
+      
+      it('should fix the parameters', function() {
+        var fixedParams = azuredocdb.fixParameters(parameters);
+        paramsToValidate.forEach(function(param){
+          should.exist(fixedParams[param]);
+        });
+        fixedParams.docDbAccountName.should.equal('fake-name');
+      });
+    });
+  });
+});

--- a/test/unit/services/azuremysqldb/fixParameters-spec.js
+++ b/test/unit/services/azuremysqldb/fixParameters-spec.js
@@ -1,0 +1,70 @@
+/* jshint camelcase: false */
+/* jshint newcap: false */
+/* global describe, before, it */
+
+var should = require('should');
+var azuremysqldb = require('../../../../lib/services/azuremysqldb/');
+
+describe('MySqlDb', function() {
+
+  describe('fixParameters', function() {
+    before(function() {
+      process.env['ALLOW_TO_GENERATE_NAMES_AND_PASSWORDS_FOR_THE_MISSING'] = 'true';
+      process.env['DEFAULT_RESOURCE_GROUP'] = 'azure-service-broker';
+      process.env['DEFAULT_LOCATION'] = 'eastus';
+      process.env['DEFAULT_PARAMETERS_AZURE_MYSQLDB'] = '{\
+        "mysqlServerParameters": {\
+          "allowMysqlServerFirewallRules": [\
+            {\
+              "ruleName": "all",\
+              "startIpAddress": "0.0.0.0",\
+              "endIpAddress": "255.255.255.255"\
+            }\
+          ],\
+          "properties": {\
+            "version": "5.6",\
+            "sslEnforcement": "Disabled",\
+            "storageMB": 51200\
+          }\
+        }\
+      }';
+    });
+    
+    var paramsToValidate = ['resourceGroup', 'mysqlServerName', 'location', 'mysqlServerParameters'];
+      
+    describe('When no parameter passed in', function() {
+      var parameters = {};
+      
+      it('should fix the parameters', function() {
+        var fixedParams = azuremysqldb.fixParameters(parameters);
+        paramsToValidate.forEach(function(param){
+          should.exist(fixedParams[param]);
+        });
+      });
+    });
+
+    describe('When part of parameters passed in: version', function() {
+      var parameters = {'mysqlServerParameters': { 'properties': {'version': 'fake-version'}}};
+      
+      it('should fix the parameters', function() {
+        var fixedParams = azuremysqldb.fixParameters(parameters);
+        paramsToValidate.forEach(function(param){
+          should.exist(fixedParams[param]);
+        });
+        fixedParams.mysqlServerParameters.properties.version.should.equal('fake-version');
+      });
+    });
+    
+    describe('When part of parameters passed in: mysqlServerName', function() {
+      var parameters = {'mysqlServerName': 'fake-name'};
+      
+      it('should fix the parameters', function() {
+        var fixedParams = azuremysqldb.fixParameters(parameters);
+        paramsToValidate.forEach(function(param){
+          should.exist(fixedParams[param]);
+        });
+        fixedParams.mysqlServerName.should.equal('fake-name');
+      });
+    });
+  });
+});

--- a/test/unit/services/azuremysqldb/index-spec.js
+++ b/test/unit/services/azuremysqldb/index-spec.js
@@ -33,6 +33,7 @@ describe('MySqlDb - Index - Provision', function() {
             }
         };
         
+        delete require.cache[require.resolve('../../../../lib/services/azuremysqldb/')];
         require('../../../../lib/services/azuremysqldb/cmd-provision');
         require.cache[require.resolve('../../../../lib/services/azuremysqldb/cmd-provision')].exports = function(_) {
           this.provision = function (_, callback) { 

--- a/test/unit/services/azurepostgresqldb/fixParameters-spec.js
+++ b/test/unit/services/azurepostgresqldb/fixParameters-spec.js
@@ -1,0 +1,109 @@
+/* jshint camelcase: false */
+/* jshint newcap: false */
+/* global describe, before, it */
+
+var should = require('should');
+var azurepostgresqldb = require('../../../../lib/services/azurepostgresqldb/');
+
+describe('PostgreSqlDb', function() {
+
+  describe('fixParameters - allow to generate names and passwords', function() {
+    before(function() {
+      process.env['ALLOW_TO_GENERATE_NAMES_AND_PASSWORDS_FOR_THE_MISSING'] = 'true';
+      process.env['DEFAULT_RESOURCE_GROUP'] = 'azure-service-broker';
+      process.env['DEFAULT_LOCATION'] = 'eastus';
+      process.env['DEFAULT_PARAMETERS_AZURE_POSTGRESQLDB'] = '{\
+        "postgresqlServerParameters": {\
+          "allowpostgresqlServerFirewallRules": [\
+            {\
+              "ruleName": "all",\
+              "startIpAddress": "0.0.0.0",\
+              "endIpAddress": "255.255.255.255"\
+            }\
+          ],\
+          "properties": {\
+            "version": "5.6",\
+            "sslEnforcement": "Disabled",\
+            "storageMB": 51200\
+          }\
+        }\
+      }';
+    });
+    
+    var paramsToValidate = ['resourceGroup', 'postgresqlServerName', 'location', 'postgresqlServerParameters'];
+      
+    describe('When no parameter passed in', function() {
+      var parameters = {};
+      
+      it('should fix the parameters', function() {
+        var fixedParams = azurepostgresqldb.fixParameters(parameters);
+        paramsToValidate.forEach(function(param){
+          should.exist(fixedParams[param]);
+        });
+      });
+    });
+
+    describe('When part of parameters passed in: version', function() {
+      var parameters = {'postgresqlServerParameters': { 'properties': {'version': 'fake-version'}}};
+      
+      it('should fix the parameters', function() {
+        var fixedParams = azurepostgresqldb.fixParameters(parameters);
+        paramsToValidate.forEach(function(param){
+          should.exist(fixedParams[param]);
+        });
+        fixedParams.postgresqlServerParameters.properties.version.should.equal('fake-version');
+      });
+    });
+    
+    describe('When part of parameters passed in: postgresqlServerName', function() {
+      var parameters = {'postgresqlServerName': 'fake-name'};
+      
+      it('should fix the parameters', function() {
+        var fixedParams = azurepostgresqldb.fixParameters(parameters);
+        paramsToValidate.forEach(function(param){
+          should.exist(fixedParams[param]);
+        });
+        fixedParams.postgresqlServerName.should.equal('fake-name');
+      });
+    });
+  });
+  
+  describe('fixParameters - not allow to generate names and passwords', function() {
+    before(function() {
+      process.env['ALLOW_TO_GENERATE_NAMES_AND_PASSWORDS_FOR_THE_MISSING'] = 'false';
+      process.env['DEFAULT_RESOURCE_GROUP'] = 'azure-service-broker';
+      process.env['DEFAULT_LOCATION'] = 'eastus';
+      process.env['DEFAULT_PARAMETERS_AZURE_POSTGRESQLDB'] = '{\
+        "postgresqlServerParameters": {\
+          "allowpostgresqlServerFirewallRules": [\
+            {\
+              "ruleName": "all",\
+              "startIpAddress": "0.0.0.0",\
+              "endIpAddress": "255.255.255.255"\
+            }\
+          ],\
+          "properties": {\
+            "version": "5.6",\
+            "sslEnforcement": "Disabled",\
+            "storageMB": 51200\
+          }\
+        }\
+      }';
+    });
+    
+    var paramsToValidate = ['resourceGroup', 'location', 'postgresqlServerParameters'];
+    describe('When no parameter passed in', function() {
+      var parameters = {};
+      
+      it('should fix the parameters', function() {
+        var fixedParams = azurepostgresqldb.fixParameters(parameters);
+        paramsToValidate.forEach(function(param){
+          should.exist(fixedParams[param]);
+        });
+        should.not.exist(fixedParams.postgresqlServerName);
+        should.not.exist(fixedParams.postgresqlServerParameters.properties.administratorLogin);
+      });
+    });
+
+  });
+});

--- a/test/unit/services/azurepostgresqldb/index-spec.js
+++ b/test/unit/services/azurepostgresqldb/index-spec.js
@@ -33,6 +33,7 @@ describe('PostgreSqlDb - Index - Provision', function() {
             }
         };
         
+        delete require.cache[require.resolve('../../../../lib/services/azurepostgresqldb/')];
         require('../../../../lib/services/azurepostgresqldb/cmd-provision');
         require.cache[require.resolve('../../../../lib/services/azurepostgresqldb/cmd-provision')].exports = function(_) {
           this.provision = function (_, callback) { 

--- a/test/unit/services/azurerediscache/fixParameters-spec.js
+++ b/test/unit/services/azurerediscache/fixParameters-spec.js
@@ -1,0 +1,64 @@
+/* jshint camelcase: false */
+/* jshint newcap: false */
+/* global describe, before, it */
+
+var should = require('should');
+var azurerediscache = require('../../../../lib/services/azurerediscache/');
+
+describe('RedisCache', function() {
+
+  describe('fixParameters', function() {
+    before(function() {
+      process.env['ALLOW_TO_GENERATE_NAMES_AND_PASSWORDS_FOR_THE_MISSING'] = 'true';
+      process.env['DEFAULT_RESOURCE_GROUP'] = 'azure-service-broker';
+      process.env['DEFAULT_LOCATION'] = 'eastus';
+      process.env['DEFAULT_PARAMETERS_AZURE_REDISCACHE'] = '{\
+        "parameters": {\
+          "enableNonSslPort": false,\
+          "sku": {\
+            "name": "Basic",\
+            "family": "C",\
+            "capacity": 0\
+          }\
+        }\
+      }';
+    });
+    
+    var paramsToValidate = ['resourceGroup', 'cacheName', 'location', 'parameters'];
+      
+    describe('When no parameter passed in', function() {
+      var parameters = {};
+      
+      it('should fix the parameters', function() {
+        var fixedParams = azurerediscache.fixParameters(parameters);
+        paramsToValidate.forEach(function(param){
+          should.exist(fixedParams[param]);
+        });
+      });
+    });
+
+    describe('When part of parameters passed in: messagingTier', function() {
+      var parameters = {'parameters': {'sku': {'name': 'Standard'}} };
+      
+      it('should fix the parameters', function() {
+        var fixedParams = azurerediscache.fixParameters(parameters);
+        paramsToValidate.forEach(function(param){
+          should.exist(fixedParams[param]);
+        });
+        fixedParams.parameters.sku.name.should.equal('Standard');
+      });
+    });
+    
+    describe('When part of parameters passed in: cacheName', function() {
+      var parameters = {'cacheName': 'fake-name'};
+      
+      it('should fix the parameters', function() {
+        var fixedParams = azurerediscache.fixParameters(parameters);
+        paramsToValidate.forEach(function(param){
+          should.exist(fixedParams[param]);
+        });
+        fixedParams.cacheName.should.equal('fake-name');
+      });
+    });
+  });
+});

--- a/test/unit/services/azureservicebus/fixParameters-spec.js
+++ b/test/unit/services/azureservicebus/fixParameters-spec.js
@@ -1,0 +1,58 @@
+/* jshint camelcase: false */
+/* jshint newcap: false */
+/* global describe, before, it */
+
+var should = require('should');
+var azureservicebus = require('../../../../lib/services/azureservicebus/');
+
+describe('ServiceBus', function() {
+
+  describe('fixParameters', function() {
+    before(function() {
+      process.env['ALLOW_TO_GENERATE_NAMES_AND_PASSWORDS_FOR_THE_MISSING'] = 'true';
+      process.env['DEFAULT_RESOURCE_GROUP'] = 'azure-service-broker';
+      process.env['DEFAULT_LOCATION'] = 'eastus';
+      process.env['DEFAULT_PARAMETERS_AZURE_SERVICEBUS'] = '{\
+        "type": "Messaging",\
+        "messagingTier": "Standard"\
+      }';
+    });
+    
+    var paramsToValidate = ['resourceGroup', 'namespaceName', 'location', 'type', 'messagingTier'];
+      
+    describe('When no parameter passed in', function() {
+      var parameters = {};
+      
+      it('should fix the parameters', function() {
+        var fixedParams = azureservicebus.fixParameters(parameters);
+        paramsToValidate.forEach(function(param){
+          should.exist(fixedParams[param]);
+        });
+      });
+    });
+
+    describe('When part of parameters passed in: messagingTier', function() {
+      var parameters = {'messagingTier': 'Basic'};
+      
+      it('should fix the parameters', function() {
+        var fixedParams = azureservicebus.fixParameters(parameters);
+        paramsToValidate.forEach(function(param){
+          should.exist(fixedParams[param]);
+        });
+        fixedParams.messagingTier.should.equal('Basic');
+      });
+    });
+    
+    describe('When part of parameters passed in: namespaceName', function() {
+      var parameters = {'namespaceName': 'fake-name'};
+      
+      it('should fix the parameters', function() {
+        var fixedParams = azureservicebus.fixParameters(parameters);
+        paramsToValidate.forEach(function(param){
+          should.exist(fixedParams[param]);
+        });
+        fixedParams.namespaceName.should.equal('fake-name');
+      });
+    });
+  });
+});

--- a/test/unit/services/azuresqldb/fixParameters-spec.js
+++ b/test/unit/services/azuresqldb/fixParameters-spec.js
@@ -1,0 +1,123 @@
+/* jshint camelcase: false */
+/* jshint newcap: false */
+/* global describe, before, it */
+
+var should = require('should');
+var azuresqldb = require('../../../../lib/services/azuresqldb/');
+
+describe('SqlDb', function() {
+
+  describe('fixParameters - new server', function() {
+    before(function() {
+      process.env['ALLOW_TO_GENERATE_NAMES_AND_PASSWORDS_FOR_THE_MISSING'] = 'true';
+      process.env['DEFAULT_RESOURCE_GROUP'] = 'azure-service-broker';
+      process.env['DEFAULT_LOCATION'] = 'eastus';
+      process.env['DEFAULT_PARAMETERS_AZURE_SQLDB'] = '{\
+        "sqlServerParameters": {\
+          "allowSqlServerFirewallRules": [\
+            {\
+              "ruleName": "all",\
+              "startIpAddress": "0.0.0.0",\
+              "endIpAddress": "255.255.255.255"\
+            }\
+          ]\
+        },\
+        "transparentDataEncryption": true,\
+        "sqldbParameters": {\
+          "properties": {\
+            "collation": "SQL_Latin1_General_CP1_CI_AS"\
+          }\
+        }\
+      }';
+    });
+    
+    var paramsToValidate = ['resourceGroup', 'sqlServerName', 'location', 'sqlServerParameters', 'sqldbName', 'transparentDataEncryption', 'sqldbParameters'];
+      
+    describe('When no parameter passed in', function() {
+      var parameters = {};
+      
+      it('should fix the parameters', function() {
+        var fixedParams = azuresqldb.fixParameters(parameters);
+        paramsToValidate.forEach(function(param){
+          should.exist(fixedParams[param]);
+        });
+      });
+    });
+
+    describe('When part of parameters passed in: collation', function() {
+      var parameters = {'sqldbParameters': { 'properties': {'collation': 'fake-collation'}}};
+      
+      it('should fix the parameters', function() {
+        var fixedParams = azuresqldb.fixParameters(parameters);
+        paramsToValidate.forEach(function(param){
+          should.exist(fixedParams[param]);
+        });
+        fixedParams.sqldbParameters.properties.collation.should.equal('fake-collation');
+      });
+    });
+    
+    describe('When part of parameters passed in: sqldbName', function() {
+      var parameters = {'sqldbName': 'fake-name'};
+      
+      it('should fix the parameters', function() {
+        var fixedParams = azuresqldb.fixParameters(parameters);
+        paramsToValidate.forEach(function(param){
+          should.exist(fixedParams[param]);
+        });
+        fixedParams.sqldbName.should.equal('fake-name');
+      });
+    });
+  });
+  
+  describe('fixParameters - existing server', function() {
+    process.env['ALLOW_TO_GENERATE_NAMES_AND_PASSWORDS_FOR_THE_MISSING'] = 'true';
+    process.env['DEFAULT_RESOURCE_GROUP'] = 'azure-service-broker';
+    process.env['DEFAULT_LOCATION'] = 'eastus';
+    process.env['DEFAULT_PARAMETERS_AZURE_SQLDB'] = '{\
+      "sqlServerParameters": {\
+        "allowSqlServerFirewallRules": [\
+          {\
+            "ruleName": "all",\
+            "startIpAddress": "0.0.0.0",\
+            "endIpAddress": "255.255.255.255"\
+          }\
+        ]\
+      },\
+      "transparentDataEncryption": true,\
+      "sqldbParameters": {\
+        "properties": {\
+          "collation": "SQL_Latin1_General_CP1_CI_AS"\
+        }\
+      }\
+    }';
+    
+    var accountPool = {
+      'sqldb': {
+        'sqlservera': {
+          'resourceGroup': 'fake-rg',
+          'location': 'fake-location',
+          'administratorLogin': 'fake-admin',
+          'administratorLoginPassword': 'fake-pwd'
+        }
+      }
+    };
+    
+    var paramsToValidate = ['sqlServerName', 'sqldbName', 'transparentDataEncryption', 'sqldbParameters'];
+    
+    describe('When only server name passed in: collation', function() {
+      var parameters = {'sqlServerName': 'sqlservera'};
+      
+      it('should fix the parameters', function() {
+        var fixedParams = azuresqldb.fixParameters(parameters, accountPool);
+        paramsToValidate.forEach(function(param){
+          should.exist(fixedParams[param]);
+        });
+        
+        should.not.exist(fixedParams['resourceGroup']);
+        should.not.exist(fixedParams['location']);
+        should.not.exist(fixedParams['sqlServerParameters']);
+      });
+    });
+  });
+  
+});

--- a/test/unit/services/azuresqldb/provision-spec.js
+++ b/test/unit/services/azuresqldb/provision-spec.js
@@ -70,7 +70,7 @@ describe('SqlDb - Provision - PreConditions', function () {
         });
     });
 
-    describe('a depreciated parameter "sqlServerCreateIfNotExist" is provided', function () {
+    describe('a deprecated parameter "sqlServerCreateIfNotExist" is provided', function () {
         before(function () {
             params = {
                 instance_id: 'e2778b98-0b6b-11e6-9db3-000d3a002ed5',

--- a/test/unit/services/azurestorage/fixParameters-spec.js
+++ b/test/unit/services/azurestorage/fixParameters-spec.js
@@ -1,0 +1,57 @@
+/* jshint camelcase: false */
+/* jshint newcap: false */
+/* global describe, before, it */
+
+var should = require('should');
+var azurestorage = require('../../../../lib/services/azurestorage/');
+
+describe('Storage', function() {
+
+  describe('fixParameters', function() {
+    before(function() {
+      process.env['ALLOW_TO_GENERATE_NAMES_AND_PASSWORDS_FOR_THE_MISSING'] = 'true';
+      process.env['DEFAULT_RESOURCE_GROUP'] = 'azure-service-broker';
+      process.env['DEFAULT_LOCATION'] = 'eastus';
+      process.env['DEFAULT_PARAMETERS_AZURE_STORAGE'] = '{\
+        "accountType": "Standard_LRS"\
+      }';
+    });
+    
+    var paramsToValidate = ['resourceGroup', 'storageAccountName', 'location', 'accountType'];
+      
+    describe('When no parameter passed in', function() {
+      var parameters = {};
+      
+      it('should fix the parameters', function() {
+        var fixedParams = azurestorage.fixParameters(parameters);
+        paramsToValidate.forEach(function(param){
+          should.exist(fixedParams[param]);
+        });
+      });
+    });
+
+    describe('When part of parameters passed in: accountType', function() {
+      var parameters = {'accountType': 'fake-type'};
+      
+      it('should fix the parameters', function() {
+        var fixedParams = azurestorage.fixParameters(parameters);
+        paramsToValidate.forEach(function(param){
+          should.exist(fixedParams[param]);
+        });
+        fixedParams.accountType.should.equal('fake-type');
+      });
+    });
+    
+    describe('When part of parameters passed in: storageAccountName', function() {
+      var parameters = {'storageAccountName': 'fake-name'};
+      
+      it('should fix the parameters', function() {
+        var fixedParams = azurestorage.fixParameters(parameters);
+        paramsToValidate.forEach(function(param){
+          should.exist(fixedParams[param]);
+        });
+        fixedParams.storageAccountName.should.equal('fake-name');
+      });
+    });
+  });
+});

--- a/test/unit/services/azurestorage/index-spec.js
+++ b/test/unit/services/azurestorage/index-spec.js
@@ -54,10 +54,10 @@ var provisioningResult = {
 };
 
 var parameters = {
-  resource_group_name: resourceGroupName,
-  storage_account_name: storageAccountName,
+  resourceGroup: resourceGroupName,
+  storageAccountName: storageAccountName,
   location: location,
-  account_type: accountType
+  accountType: accountType
 };
 
 describe('Storage - Index - Provision', function() {


### PR DESCRIPTION
fix https://github.com/Azure/meta-azure-service-broker/issues/115
Support to create new instances with a simple command. For example:
```
cf create-service azure-cosmosdb standard mycosmosdb
```
