### PR TITLE
check resource group existence before creating. (allow group and reso…

### DIFF
--- a/lib/common/msRestRequest.js
+++ b/lib/common/msRestRequest.js
@@ -123,16 +123,20 @@ function msRestRequest(url, qs, method, headers, data, callback) {
   );
 }
 
-exports.POST = function (url, headers, data, apiVersion, callback) {
-  msRestRequest(url, { 'api-version': apiVersion }, 'POST', headers, data, callback);
+exports.HEAD = function (url, headers, apiVersion, callback) {
+  msRestRequest(url, { 'api-version': apiVersion }, 'HEAD', headers, null, callback);
+};
+
+exports.GET = function (url, headers, apiVersion, callback) {
+  msRestRequest(url, { 'api-version': apiVersion }, 'GET', headers, null, callback);
 };
 
 exports.PUT = function (url, headers, data, apiVersion, callback) {
   msRestRequest(url, { 'api-version': apiVersion }, 'PUT', headers, data, callback);
 };
 
-exports.GET = function (url, headers, apiVersion, callback) {
-  msRestRequest(url, { 'api-version': apiVersion }, 'GET', headers, null, callback);
+exports.POST = function (url, headers, data, apiVersion, callback) {
+  msRestRequest(url, { 'api-version': apiVersion }, 'POST', headers, data, callback);
 };
 
 exports.DELETE = function (url, headers, apiVersion, callback) {

--- a/lib/common/resourceGroup-client.js
+++ b/lib/common/resourceGroup-client.js
@@ -8,6 +8,42 @@ var HttpStatus = require('http-status-codes');
 var common = require('./index');
 var log = common.getLogger(common.LOG_CONSTANTS.COMMON);
 
+exports.checkExistence = function(prefix, azureProperties, resourceGroupName, callback) {
+  
+  var environmentName = azureProperties.environment;
+  var environment = common.getEnvironment(environmentName);
+  var API_VERSIONS = common.API_VERSION[environmentName];
+  var resouceGroupUrl = util.format('%s/subscriptions/%s/resourceGroups/%s',
+                                    environment.resourceManagerEndpointUrl,
+                                    azureProperties.subscriptionId,
+                                    resourceGroupName);
+  
+  msRestRequest.HEAD(
+    resouceGroupUrl,
+    common.mergeCommonHeaders(util.format('%s - check resource group existence', prefix), {}),
+    API_VERSIONS.RESOURCE_GROUP,
+    function(err, response, body) {
+      common.logHttpResponse(response, util.format('%s - check resource group existence', prefix), true);
+      if(err) {
+        log.error('%s - check resource group existence, err: %j', prefix, err);
+        return callback(err);
+      }
+      // https://docs.microsoft.com/en-us/rest/api/resources/resourcegroups#ResourceGroups_CheckExistence
+      // 204 -> existed, 404 -> not existed
+      if (response.statusCode === HttpStatus.NO_CONTENT) {
+        log.info('%s - check resource group existence, succeeded: existed', prefix);
+        callback(null, true);
+      } else if (response.statusCode === HttpStatus.NOT_FOUND) {
+        log.info('%s - check resource group existence, succeeded: not existed', prefix);
+        callback(null, false);
+      } else {
+        log.error('%s - check resource group existence, err: %j', prefix, response.body);
+        return common.formatErrorFromRes(response, callback);
+      }
+    }
+  );
+};
+
 exports.createOrUpdate = function(prefix, azureProperties, resourceGroupName, groupParameters, callback) {
   
   var environmentName = azureProperties.environment;

--- a/lib/services/azurecosmosdb/client.js
+++ b/lib/services/azurecosmosdb/client.js
@@ -8,7 +8,6 @@ var crypto = require('crypto');
 
 var common = require('../../common/');
 var msRestRequest = require('../../common/msRestRequest');
-var resourceGroup = require('../../common/resourceGroup-client');
 
 var azureProperties;
 var environment;
@@ -22,16 +21,6 @@ exports.initialize = function(azure) {
   environment = common.getEnvironment(azure.environment);
 };
 
-exports.createResourceGroup = function(resourceGroupName, location, callback) {
-  resourceGroup.createOrUpdate(
-    'CosmosDb',
-    azureProperties,
-    resourceGroupName,
-    { 'location': location },
-    callback
-  );
-};
-
 exports.getCosmosDbAccount = function(resourceGroupName, cosmosDbAccountName, callback) {
   var url = util.format(
     cosmosDbUrlTemplate,
@@ -42,10 +31,10 @@ exports.getCosmosDbAccount = function(resourceGroupName, cosmosDbAccountName, ca
   
   msRestRequest.GET(
     url,
-    common.mergeCommonHeaders('Cosmosdb - getCosmosDbAccount', {}),
+    common.mergeCommonHeaders('CosmosDb - getCosmosDbAccount', {}),
     API_VERSIONS.COSMOSDB,
     function(err, res, body){
-      common.logHttpResponse(res, 'Cosmosdb - getCosmosDbAccount', true);
+      common.logHttpResponse(res, 'CosmosDb - getCosmosDbAccount', true);
       callback(err, res, body);
     }
   );
@@ -61,11 +50,11 @@ exports.createCosmosDbAccount = function(resourceGroupName, cosmosDbAccountName,
   
   msRestRequest.PUT(
     url,
-    common.mergeCommonHeaders('Cosmosdb - createCosmosDbAccount', {}),
+    common.mergeCommonHeaders('CosmosDb - createCosmosDbAccount', {}),
     params,
     API_VERSIONS.COSMOSDB,
     function (err, res, body) {
-      common.logHttpResponse(res, 'Cosmosdb - createCosmosDbAccount', true);
+      common.logHttpResponse(res, 'CosmosDb - createCosmosDbAccount', true);
       if (err) {
         return callback(err);
       }
@@ -87,11 +76,11 @@ exports.getAccountKey = function(resourceGroupName, cosmosDbAccountName, callbac
     
   msRestRequest.POST(
     url,
-    common.mergeCommonHeaders('Cosmosdb - getAccountKey', {'Content-Type': 'application/json'}),
+    common.mergeCommonHeaders('CosmosDb - getAccountKey', {'Content-Type': 'application/json'}),
     null,
     API_VERSIONS.COSMOSDB,
     function(err, res, body) {
-      common.logHttpResponse(res, 'Cosmosdb - getAccountKey', false);
+      common.logHttpResponse(res, 'CosmosDb - getAccountKey', false);
       if (err) {
         return callback(err);
       }
@@ -142,7 +131,7 @@ exports.createDocDbDatabase = function createDocDbDatabase(hostEndpoint, masterK
     if (err) {
       return callback(err);
     }
-    common.logHttpResponse(res, 'Cosmosdb - createDocDbDatabase', true);
+    common.logHttpResponse(res, 'CosmosDb - createDocDbDatabase', true);
     if (res.statusCode != HttpStatus.CREATED) {
       if (res.statusCode == HttpStatus.UNAUTHORIZED)
         return createDocDbDatabase(hostEndpoint, masterKey, databaseName, callback);
@@ -163,10 +152,10 @@ exports.deleteCosmosDbAccount = function(resourceGroupName, cosmosDbAccountName,
     cosmosDbAccountName);
   msRestRequest.DELETE(
     url,
-    common.mergeCommonHeaders('Cosmosdb - deleteCosmosDbAccount', {}),
+    common.mergeCommonHeaders('CosmosDb - deleteCosmosDbAccount', {}),
     API_VERSIONS.COSMOSDB,
     function (err, res, body) {
-      common.logHttpResponse(res, 'Cosmosdb - deleteCosmosDbAccount', true);
+      common.logHttpResponse(res, 'CosmosDb - deleteCosmosDbAccount', true);
       if (err) {
         return callback(err);
       }

--- a/lib/services/azurecosmosdb/cmd-provision.js
+++ b/lib/services/azurecosmosdb/cmd-provision.js
@@ -5,6 +5,7 @@ var async = require('async');
 var common = require('../../common');
 var HttpStatus = require('http-status-codes');
 var _ = require('underscore');
+var resourceGroup = require('../../common/resourceGroup-client');
 
 var cosmosDbProvision = function(params) {
 
@@ -32,7 +33,14 @@ var cosmosDbProvision = function(params) {
         });
       },
       function(callback) {
-        cosmosDb.createResourceGroup(resourceGroupName, location, callback);
+        resourceGroup.checkExistence('CosmosDb', params.azure, resourceGroupName, callback);
+      },
+      function(existed, callback) {
+        if (existed) {
+          callback(null);
+        } else {
+          resourceGroup.createOrUpdate('CosmosDb', params.azure, resourceGroupName, { 'location': location }, callback);
+        }
       },
       function(callback) {
         if (_.isUndefined(reqParams.tags)) {

--- a/lib/services/azuredocdb/client.js
+++ b/lib/services/azuredocdb/client.js
@@ -8,7 +8,6 @@ var crypto = require('crypto');
 
 var common = require('../../common/');
 var msRestRequest = require('../../common/msRestRequest');
-var resourceGroup = require('../../common/resourceGroup-client');
 
 var azureProperties;
 var environment;
@@ -20,16 +19,6 @@ exports.initialize = function(azure) {
   azureProperties = azure;
   API_VERSIONS = common.API_VERSION[azure.environment];
   environment = common.getEnvironment(azure.environment);
-};
-
-exports.createResourceGroup = function(resourceGroupName, location, callback) {
-  resourceGroup.createOrUpdate(
-    'DocDb',
-    azureProperties,
-    resourceGroupName,
-    { 'location': location },
-    callback
-  );
 };
 
 exports.getDocDbAccount = function(resourceGroupName, docDbAccountName, callback) {

--- a/lib/services/azuredocdb/cmd-provision.js
+++ b/lib/services/azuredocdb/cmd-provision.js
@@ -4,6 +4,7 @@
 var async = require('async');
 var common = require('../../common');
 var HttpStatus = require('http-status-codes');
+var resourceGroup = require('../../common/resourceGroup-client');
 
 var docDbProvision = function(params) {
 
@@ -30,7 +31,14 @@ var docDbProvision = function(params) {
         });
       },
       function(callback) {
-        docDb.createResourceGroup(resourceGroupName, location, callback);
+        resourceGroup.checkExistence('DocDb', params.azure, resourceGroupName, callback);
+      },
+      function(existed, callback) {
+        if (existed) {
+          callback(null);
+        } else {
+          resourceGroup.createOrUpdate('DocDb', params.azure, resourceGroupName, { 'location': location }, callback);
+        }
       },
       function(callback) {
         var params = {

--- a/lib/services/azureeventhubs/index.js
+++ b/lib/services/azureeventhubs/index.js
@@ -10,6 +10,7 @@ var common = require('../../common/');
 var config = require('./service');
 var log = common.getLogger(config.name);
 var util = require('util');
+var resourceGroup = require('../../common/resourceGroup-client');
 
 var Handlers = {};
 
@@ -67,7 +68,14 @@ Handlers.provision = function(params, next) {
       utils.checkNamespaceAvailability(azure_config, callback);
     },
     function(callback) {
-      utils.createResourceGroup(azure_config, callback);
+      resourceGroup.checkExistence(config.name, params.azure, azure_config.resourceGroupName, callback);
+    },
+    function(existed, callback) {
+      if (existed) {
+        callback(null);
+      } else {
+        resourceGroup.createOrUpdate(config.name, params.azure, azure_config.resourceGroupName, {location: azure_config.location}, callback);
+      }
     },
     function(callback) {
       utils.createNamespace(azure_config, callback);

--- a/lib/services/azuremysqldb/client.js
+++ b/lib/services/azuremysqldb/client.js
@@ -5,7 +5,6 @@ var HttpStatus = require('http-status-codes');
 var util = require('util');
 var common = require('../../common/');
 var msRestRequest = require('../../common/msRestRequest');
-var resourceGroup = require('../../common/resourceGroup-client');
 var Config = require('./service');
 var log = common.getLogger(Config.name);
 
@@ -37,19 +36,6 @@ mysqldbOperations.prototype.setParameters = function (resourceGroupName, mysqlSe
         'Content-Type': 'application/json; charset=UTF-8'
     };
 
-};
-
-mysqldbOperations.prototype.createResourceGroup = function (resourceGroupName, groupParameters, callback) {
-
-    var that = this;
-
-    resourceGroup.createOrUpdate(
-        'MySqlDb',
-        that.azure,
-        resourceGroupName,
-        groupParameters,
-        callback
-    );
 };
 
 mysqldbOperations.prototype.checkComplete = function (url, callback) {

--- a/lib/services/azuremysqldb/cmd-provision.js
+++ b/lib/services/azuremysqldb/cmd-provision.js
@@ -8,6 +8,7 @@ var Config = require('./service');
 var common = require('../../common');
 var log = common.getLogger(Config.name);
 var util = require('util');
+var resourceGroup = require('../../common/resourceGroup-client');
 
 var mysqldbProvision = function (params) {
 
@@ -48,9 +49,6 @@ var mysqldbProvision = function (params) {
         mysqldbOperations.setParameters(resourceGroupName, mysqlServerName, location);
         
         async.waterfall([
-            function (callback) {
-                mysqldbOperations.createResourceGroup(resourceGroupName, groupParameters, callback);
-            },
             function (callback) {  // get mysql server status (existence check)
                 mysqldbOperations.getServer(function (err, result) {
                     if (err) {
@@ -58,42 +56,52 @@ var mysqldbProvision = function (params) {
                         return callback(err);
                     } else {
                         log.info('cmd-provision: get the mysql server: %j', result);
-                        callback(null, result);
+                        if (result.statusCode === HttpStatus.NOT_FOUND) {
+                            callback(null);
+                        } else if (result.statusCode === HttpStatus.OK) {  // mysql server exists
+                            var error = Error('The server name is not available.');
+                            error.statusCode = HttpStatus.CONFLICT;
+                            callback(error);
+                        } else {
+                            var errorMessage = util.format('Unexpected result: %j', result);
+                            log.error(errorMessage);
+                            callback(Error(errorMessage));
+                        }
                     }
                 });
             },
-            function (result, callback) {   // create mysql server if not exist
-                if (result.statusCode === HttpStatus.NOT_FOUND) {
-                    mysqldbOperations.createServer(reqParams, function (err, serverPollingUrl) {
-                        if (err) {
-                            log.error('cmd-provision: create the mysql server: err: %j', err);
-                            callback(err);
-                        } else {
-                            log.info('cmd-provision: create the mysql server: succeeded');
-                            var result = {};
-                            result.body = {};
-                            result.body.resourceGroup = resourceGroupName;
-                            result.body.mysqlServerName = mysqlServerName;
-                            result.body.administratorLogin = administratorLogin;
-                            result.body.administratorLoginPassword = administratorLoginPassword;
-                            result.body.serverPollingUrl = serverPollingUrl;
-                            result.body.mysqlDatabaseName = reqParams.mysqlDatabaseName;
-                            
-                            result.value = {};
-                            result.value.state = 'in progress';
-                            result.value.description = 'Creating server ' + reqParams.mysqlServerName + '.';
-                            callback(null, result);
-                        }
-                    });
-                } else if (result.statusCode === HttpStatus.OK) {  // mysql server exists
-                    var error = Error('The server name is not available.');
-                    error.statusCode = HttpStatus.CONFLICT;
-                    callback(error);
+            function(callback) {
+                resourceGroup.checkExistence(Config.name, params.azure, resourceGroupName, callback);
+            },
+            function(existed, callback) {
+                if (existed) {
+                    callback(null);
                 } else {
-                    var errorMessage = util.format('Unexpected result: %j', result);
-                    log.error(errorMessage);
-                    callback(Error(errorMessage));
+                    resourceGroup.createOrUpdate(Config.name, params.azure, resourceGroupName, groupParameters, callback);
                 }
+            },
+            function (callback) {   // create mysql server if not exist
+                mysqldbOperations.createServer(reqParams, function (err, serverPollingUrl) {
+                    if (err) {
+                        log.error('cmd-provision: create the mysql server: err: %j', err);
+                        callback(err);
+                    } else {
+                        log.info('cmd-provision: create the mysql server: succeeded');
+                        var result = {};
+                        result.body = {};
+                        result.body.resourceGroup = resourceGroupName;
+                        result.body.mysqlServerName = mysqlServerName;
+                        result.body.administratorLogin = administratorLogin;
+                        result.body.administratorLoginPassword = administratorLoginPassword;
+                        result.body.serverPollingUrl = serverPollingUrl;
+                        result.body.mysqlDatabaseName = reqParams.mysqlDatabaseName;
+                            
+                        result.value = {};
+                        result.value.state = 'in progress';
+                        result.value.description = 'Creating server ' + reqParams.mysqlServerName + '.';
+                        callback(null, result);
+                    }
+                });
             }
         ], function (err, result) {
             if (err) {

--- a/lib/services/azurepostgresqldb/client.js
+++ b/lib/services/azurepostgresqldb/client.js
@@ -5,7 +5,6 @@ var HttpStatus = require('http-status-codes');
 var util = require('util');
 var common = require('../../common/');
 var msRestRequest = require('../../common/msRestRequest');
-var resourceGroup = require('../../common/resourceGroup-client');
 var Config = require('./service');
 var log = common.getLogger(Config.name);
 
@@ -37,19 +36,6 @@ postgresqldbOperations.prototype.setParameters = function (resourceGroupName, po
         'Content-Type': 'application/json; charset=UTF-8'
     };
 
-};
-
-postgresqldbOperations.prototype.createResourceGroup = function (resourceGroupName, groupParameters, callback) {
-
-    var that = this;
-
-    resourceGroup.createOrUpdate(
-        'PostgreSqlDb',
-        that.azure,
-        resourceGroupName,
-        groupParameters,
-        callback
-    );
 };
 
 postgresqldbOperations.prototype.checkComplete = function (url, callback) {

--- a/lib/services/azurepostgresqldb/cmd-provision.js
+++ b/lib/services/azurepostgresqldb/cmd-provision.js
@@ -8,6 +8,7 @@ var Config = require('./service');
 var common = require('../../common');
 var log = common.getLogger(Config.name);
 var util = require('util');
+var resourceGroup = require('../../common/resourceGroup-client');
 
 var postgresqldbProvision = function (params) {
 
@@ -48,52 +49,58 @@ var postgresqldbProvision = function (params) {
         postgresqldbOperations.setParameters(resourceGroupName, postgresqlServerName, location);
         
         async.waterfall([
-            function (callback) {
-                postgresqldbOperations.createResourceGroup(resourceGroupName, groupParameters, callback);
-            },
             function (callback) {  // get postgresql server status (existence check)
                 postgresqldbOperations.getServer(function (err, result) {
                     if (err) {
                         log.error('cmd-provision: get the postgresql server: err: %j', err);
                         return callback(err);
+                    }
+                    log.info('cmd-provision: get the postgresql server: %j', result);
+                    if (result.statusCode === HttpStatus.NOT_FOUND) {
+                        callback(null);
+                    } else if (result.statusCode === HttpStatus.OK) {  // postgresql server exists
+                        var error = Error('The server name is not available.');
+                        error.statusCode = HttpStatus.CONFLICT;
+                        callback(error);
                     } else {
-                        log.info('cmd-provision: get the postgresql server: %j', result);
-                        callback(null, result);
+                        var errorMessage = util.format('Unexpected result: %j', result);
+                        log.error(errorMessage);
+                        callback(Error(errorMessage));
                     }
                 });
             },
-            function (result, callback) {   // create postgresql server if not exist
-                if (result.statusCode === HttpStatus.NOT_FOUND) {
-                    postgresqldbOperations.createServer(reqParams, function (err, serverPollingUrl) {
-                        if (err) {
-                            log.error('cmd-provision: create the postgresql server: err: %j', err);
-                            callback(err);
-                        } else {
-                            log.info('cmd-provision: create the postgresql server: succeeded');
-                            var result = {};
-                            result.body = {};
-                            result.body.resourceGroup = resourceGroupName;
-                            result.body.postgresqlServerName = postgresqlServerName;
-                            result.body.administratorLogin = administratorLogin;
-                            result.body.administratorLoginPassword = administratorLoginPassword;
-                            result.body.serverPollingUrl = serverPollingUrl;
-                            result.body.postgresqlDatabaseName = reqParams.postgresqlDatabaseName;
-                            
-                            result.value = {};
-                            result.value.state = 'in progress';
-                            result.value.description = 'Creating server ' + reqParams.postgresqlServerName + '.';
-                            callback(null, result);
-                        }
-                    });
-                } else if (result.statusCode === HttpStatus.OK) {  // postgresql server exists
-                    var error = Error('The server name is not available.');
-                    error.statusCode = HttpStatus.CONFLICT;
-                    callback(error);
+            function(callback) {
+                resourceGroup.checkExistence(Config.name, params.azure, resourceGroupName, callback);
+            },
+            function(existed, callback) {
+                if (existed) {
+                    callback(null);
                 } else {
-                    var errorMessage = util.format('Unexpected result: %j', result);
-                    log.error(errorMessage);
-                    callback(Error(errorMessage));
+                    resourceGroup.createOrUpdate(Config.name, params.azure, resourceGroupName, groupParameters, callback);
                 }
+            },
+            function (callback) {   // create postgresql server if not exist
+                postgresqldbOperations.createServer(reqParams, function (err, serverPollingUrl) {
+                    if (err) {
+                        log.error('cmd-provision: create the postgresql server: err: %j', err);
+                        callback(err);
+                    } else {
+                        log.info('cmd-provision: create the postgresql server: succeeded');
+                        var result = {};
+                        result.body = {};
+                        result.body.resourceGroup = resourceGroupName;
+                        result.body.postgresqlServerName = postgresqlServerName;
+                        result.body.administratorLogin = administratorLogin;
+                        result.body.administratorLoginPassword = administratorLoginPassword;
+                        result.body.serverPollingUrl = serverPollingUrl;
+                        result.body.postgresqlDatabaseName = reqParams.postgresqlDatabaseName;
+                            
+                        result.value = {};
+                        result.value.state = 'in progress';
+                        result.value.description = 'Creating server ' + reqParams.postgresqlServerName + '.';
+                        callback(null, result);
+                    }
+                });
             }
         ], function (err, result) {
             if (err) {

--- a/lib/services/azurerediscache/cmd-provision.js
+++ b/lib/services/azurerediscache/cmd-provision.js
@@ -25,7 +25,14 @@ var cacheProvision = function(params) {
 
     async.waterfall([
       function(callback) {
-          resourceGroup.createOrUpdate('Redis Cache', params.azure, resourceGroupName, groupParameters, callback);
+          resourceGroup.checkExistence(Config.name, params.azure, resourceGroupName, callback);
+      },
+      function(existed, callback) {
+          if (existed) {
+              callback(null);
+          } else {
+              resourceGroup.createOrUpdate(Config.name, params.azure, resourceGroupName, groupParameters, callback);
+          }
       },
       function(callback) {
         log.debug('Redis Cache, redis.provision, resourceGroupName: %s, cacheName: %s', resourceGroupName, cacheName);

--- a/lib/services/azureservicebus/index.js
+++ b/lib/services/azureservicebus/index.js
@@ -10,6 +10,7 @@ var common = require('../../common/');
 var config = require('./service');
 var log = common.getLogger(config.name);
 var util = require('util');
+var resourceGroup = require('../../common/resourceGroup-client');
 
 var Handlers = {};
 
@@ -78,7 +79,14 @@ Handlers.provision = function(params, next) {
       utils.checkNamespaceAvailability(azure_config, callback);
     },
     function(callback) {
-      utils.createResourceGroup(azure_config, callback);
+      resourceGroup.checkExistence(config.name, params.azure, azure_config.resourceGroupName, callback);
+    },
+    function(existed, callback) {
+      if (existed) {
+        callback(null);
+      } else {
+        resourceGroup.createOrUpdate(config.name, params.azure, azure_config.resourceGroupName, {location: azure_config.location}, callback);
+      }
     },
     function(callback) {
       utils.createNamespace(azure_config, callback);

--- a/lib/services/azureservicebus/utils.js
+++ b/lib/services/azureservicebus/utils.js
@@ -5,7 +5,6 @@
 
 var util = require('util');
 var common = require('../../common');
-var resourceGroup = require('../../common/resourceGroup-client');
 var msRestRequest = require('../../common/msRestRequest');
 var HttpStatus = require('http-status-codes');
 
@@ -21,16 +20,6 @@ exports.init = function(azure) {
   environment = common.getEnvironment(environmentName);
 
   API_VERSION = common.API_VERSION[environmentName]['SERVICE_BUS'];
-};
-
-exports.createResourceGroup = function(azureConfig, callback) {
-  resourceGroup.createOrUpdate(
-    'ServiceBus',
-    azureProperties,
-    azureConfig.resourceGroupName,
-    { 'location': azureConfig.location },
-    callback
-  );
 };
 
 exports.createNamespace = function(azureConfig, callback) {

--- a/lib/services/azuresqldb/client.js
+++ b/lib/services/azuresqldb/client.js
@@ -5,7 +5,6 @@ var HttpStatus = require('http-status-codes');
 var util = require('util');
 var common = require('../../common/');
 var msRestRequest = require('../../common/msRestRequest');
-var resourceGroup = require('../../common/resourceGroup-client');
 var sqlDb = require('mssql');
 var Config = require('./service');
 var log = common.getLogger(Config.name);
@@ -48,19 +47,6 @@ sqldbOperations.prototype.setParameters = function (resourceGroupName, sqlServer
         'Accept': 'application/json'
     };
 
-};
-
-sqldbOperations.prototype.createResourceGroup = function (resourceGroupName, groupParameters, callback) {
-
-    var that = this;
-
-    resourceGroup.createOrUpdate(
-        'SqlDb',
-        that.azure,
-        resourceGroupName,
-        groupParameters,
-        callback
-    );
 };
 
 sqldbOperations.prototype.createFirewallRule = function (ruleName, startIpAddress, endIpAddress, callback) {

--- a/lib/services/azuresqldb/cmd-provision.js
+++ b/lib/services/azuresqldb/cmd-provision.js
@@ -9,6 +9,7 @@ var common = require('../../common');
 var log = common.getLogger(Config.name);
 var util = require('util');
 var validCollations = require('./validCollations.json');
+var resourceGroup = require('../../common/resourceGroup-client');
 
 var sqldbProvision = function (params) {
 
@@ -183,7 +184,13 @@ var sqldbProvision = function (params) {
         } else {
             async.waterfall([
                 function (callback) {
-                    sqldbOperations.createResourceGroup(resourceGroupName, groupParameters, callback);
+                    resourceGroup.checkExistence(Config.name, params.azure, resourceGroupName, callback);
+                },
+                function (existed, callback) {
+                    if (existed) {
+                        return callback(null);
+                    }
+                    resourceGroup.createOrUpdate(Config.name, params.azure, resourceGroupName, groupParameters, callback);
                 },
                 function (callback) {  // get sql server status (existence check)
                     getServer(callback);

--- a/lib/services/azurestorage/storageclient.js
+++ b/lib/services/azurestorage/storageclient.js
@@ -55,7 +55,7 @@ function createStorageAccount(resourceGroupName, storageAccountName, accountPara
 }
  
 exports.provision = function(resourceGroupName, groupParameters, storageAccountName, accountParameters, next) {
-  async.series([
+  async.waterfall([
       function(callback) {
         checkNameAvailability(storageAccountName,
           function(err, response, body) {
@@ -79,14 +79,13 @@ exports.provision = function(resourceGroupName, groupParameters, storageAccountN
         );
       },
       function(callback) {
-        resourceGroup.createOrUpdate('Storage', azureProperties, resourceGroupName, groupParameters,
-          function(err, response, body) {
-            callback(err, {
-              resourceGroupName: resourceGroupName,
-              groupParameters: groupParameters,
-            });
-          }
-        );
+        resourceGroup.checkExistence('Storage', azureProperties, resourceGroupName, callback);
+      },
+      function(existed, callback) {
+        if (existed) {
+          return callback(null);
+        }
+        resourceGroup.createOrUpdate('Storage', azureProperties, resourceGroupName, groupParameters, callback);
       },
       function(callback) {
         createStorageAccount(resourceGroupName, storageAccountName, accountParameters,
@@ -96,10 +95,7 @@ exports.provision = function(resourceGroupName, groupParameters, storageAccountN
               return callback(err);
             }
             if (response.statusCode == HttpStatus.OK || response.statusCode == HttpStatus.ACCEPTED) {
-              callback(null, {
-                storageAccountName: storageAccountName,
-                accountParameters: accountParameters,
-              });
+              callback(null);
             } else {
               var e = new Error(body);
               e.statusCode = response.statusCode;
@@ -109,10 +105,10 @@ exports.provision = function(resourceGroupName, groupParameters, storageAccountN
         );
       }
     ],
-    function(err, results) {
+    function(err) {
       var result = {
-        resourceGroupResult: results[1],
-        storageAccountResult: results[2]
+        resourceGroupResult: { resourceGroupName: resourceGroupName, groupParameters: groupParameters },
+        storageAccountResult: { storageAccountName: storageAccountName, accountParameters: accountParameters }
       };
       next(err, result);
     });

--- a/test/unit/common/msRestRequestTest.js
+++ b/test/unit/common/msRestRequestTest.js
@@ -36,15 +36,15 @@ describe('msRestRequest', function() {
 
   describe('when the token is not expired, statusCode is in AZURE_RETRY_ERROR_CODES, and retry successfully', function() {
     
-    var callTimes = 0;
+    var countCall;
     
     before(function() {
       require('request');
       require.cache[require.resolve('request')].exports = function(_, callback) {
-        ++callTimes;
-        if (callTimes == 1) {
+        ++countCall;
+        if (countCall == 1) {
           callback(null, {statusCode: 502}, {});
-        } else if (callTimes == 2) {
+        } else if (countCall == 2) {
           callback(null, {statusCode: 200}, {});
         } else {
           callback(Error('unexpected error'));
@@ -54,13 +54,45 @@ describe('msRestRequest', function() {
       msRestRequest = require('../../../lib/common/msRestRequest');
     });
     
+    beforeEach(function() {
+      countCall = 0;
+    });
+    
     after(function(){
       delete require.cache[require.resolve('request')];
     });
     
-    it('should not exist error', function(done) {
+    it('HEAD should not exist error', function(done) {
+      this.timeout(6000);
+      msRestRequest.HEAD('', {}, '', function(err) {
+        done(err);
+      });
+    });
+    
+    it('GET should not exist error', function(done) {
       this.timeout(6000);
       msRestRequest.GET('', {}, '', function(err) {
+        done(err);
+      });
+    });
+    
+    it('PUT should not exist error', function(done) {
+      this.timeout(6000);
+      msRestRequest.PUT('', {}, '', undefined, function(err) {
+        done(err);
+      });
+    });
+    
+    it('POST should not exist error', function(done) {
+      this.timeout(6000);
+      msRestRequest.POST('', {}, '', undefined, function(err) {
+        done(err);
+      });
+    });
+    
+    it('DELETE should not exist error', function(done) {
+      this.timeout(6000);
+      msRestRequest.DELETE('', {}, '', function(err) {
         done(err);
       });
     });
@@ -68,15 +100,15 @@ describe('msRestRequest', function() {
   
   describe('when the token is expired, statusCode is not in AZURE_RETRY_ERROR_CODES, and retry successfully', function() {
     
-    var callTimes = 0;
+    var countCall = 0;
     
     before(function() {
       require('request');
       require.cache[require.resolve('request')].exports = function(_, callback) {
-        ++callTimes;
-        if (callTimes == 1) {
+        ++countCall;
+        if (countCall == 1) {
           callback(null, {statusCode: 401}, {});
-        } else if (callTimes == 2) {
+        } else if (countCall == 2) {
           callback(null, {statusCode: 200}, {});
         } else {
           callback(Error('unexpected error'));

--- a/test/unit/services/azurecosmosdb/index-spec.js
+++ b/test/unit/services/azurecosmosdb/index-spec.js
@@ -22,6 +22,10 @@ describe('CosmosDb - Index - Provision', function() {
         msRestRequest.GET = sinon.stub();
         msRestRequest.GET.withArgs('https://management.azure.com//subscriptions/55555555-4444-3333-2222-111111111111/resourcegroups/cosmosDbResourceGroup/providers/Microsoft.DocumentDB/databaseAccounts/eCosmosDbAccount')
           .yields(null, {statusCode: 404});
+        
+        msRestRequest.HEAD = sinon.stub();
+        msRestRequest.HEAD.withArgs('https://management.azure.com//subscriptions/55555555-4444-3333-2222-111111111111/resourceGroups/cosmosDbResourceGroup')
+          .yields(null, {statusCode: 404});
           
         msRestRequest.PUT = sinon.stub();
         msRestRequest.PUT.withArgs('https://management.azure.com//subscriptions/55555555-4444-3333-2222-111111111111/resourceGroups/cosmosDbResourceGroup')

--- a/test/unit/services/azurecosmosdb/provision-spec.js
+++ b/test/unit/services/azurecosmosdb/provision-spec.js
@@ -72,10 +72,14 @@ describe('CosmosDb - Provision - Execution - CosmosDb that doesn\'t previsouly e
         cosmosDbName: 'testCosmos',
         location: 'westus'
       },
-      azure : azure,
+      azure : azure
     };
     cp = new cmdProvision(validParams);
     
+    msRestRequest.HEAD = sinon.stub();
+    msRestRequest.HEAD.withArgs('https://management.azure.com//subscriptions/55555555-4444-3333-2222-111111111111/resourceGroups/cosmosDbResourceGroup')
+      .yields(null, {statusCode: 404});
+
     msRestRequest.GET = sinon.stub();
     msRestRequest.GET.withArgs('https://management.azure.com//subscriptions/55555555-4444-3333-2222-111111111111/resourcegroups/cosmosDbResourceGroup/providers/Microsoft.DocumentDB/databaseAccounts/testCosmosDbAccount')
       .yields(null, {statusCode: 404});

--- a/test/unit/services/azuredocdb/index-spec.js
+++ b/test/unit/services/azuredocdb/index-spec.js
@@ -37,6 +37,10 @@ describe('DocumentDb - Index - Provision', function() {
         msRestRequest.GET = sinon.stub();
         msRestRequest.GET.withArgs('https://management.azure.com//subscriptions/55555555-4444-3333-2222-111111111111/resourcegroups/docDbResourceGroup/providers/Microsoft.DocumentDB/databaseAccounts/eDocDbAccount')
           .yields(null, {statusCode: 404});
+        
+        msRestRequest.HEAD = sinon.stub();
+        msRestRequest.HEAD.withArgs('https://management.azure.com//subscriptions/55555555-4444-3333-2222-111111111111/resourceGroups/docDbResourceGroup')
+          .yields(null, {statusCode: 404});
           
         msRestRequest.PUT = sinon.stub();
         msRestRequest.PUT.withArgs('https://management.azure.com//subscriptions/55555555-4444-3333-2222-111111111111/resourceGroups/docDbResourceGroup')

--- a/test/unit/services/azuredocdb/provision-spec.js
+++ b/test/unit/services/azuredocdb/provision-spec.js
@@ -72,10 +72,14 @@ describe('DocumentDb - Provision - Execution - DocDb that doesn\'t previsouly ex
         docDbName: 'testDoc',
         location: 'westus'
       },
-      azure : azure,
+      azure : azure
     };
     cp = new cmdProvision(validParams);
     
+    msRestRequest.HEAD = sinon.stub();
+    msRestRequest.HEAD.withArgs('https://management.azure.com//subscriptions/55555555-4444-3333-2222-111111111111/resourceGroups/docDbResourceGroup')
+      .yields(null, {statusCode: 404});
+
     msRestRequest.GET = sinon.stub();
     msRestRequest.GET.withArgs('https://management.azure.com//subscriptions/55555555-4444-3333-2222-111111111111/resourcegroups/docDbResourceGroup/providers/Microsoft.DocumentDB/databaseAccounts/testDocDbAccount')
       .yields(null, {statusCode: 404});

--- a/test/unit/services/azureeventhubs/provision-spec.js
+++ b/test/unit/services/azureeventhubs/provision-spec.js
@@ -59,7 +59,11 @@ describe('EventHubs', function() {
         msRestRequest.GET = sinon.stub();
         msRestRequest.GET.withArgs('https://management.azure.com//subscriptions/55555555-4444-3333-2222-111111111111/resourceGroups/mysbtest/providers/Microsoft.EventHub/namespaces/mysb')
           .yields(null, {statusCode: 404});
-          
+        
+        msRestRequest.HEAD = sinon.stub();
+        msRestRequest.HEAD.withArgs('https://management.azure.com//subscriptions/55555555-4444-3333-2222-111111111111/resourceGroups/mysbtest')
+          .yields(null, {statusCode: 404});
+
         msRestRequest.PUT = sinon.stub();
         msRestRequest.PUT.withArgs('https://management.azure.com//subscriptions/55555555-4444-3333-2222-111111111111/resourceGroups/mysbtest')
           .yields(null, {statusCode: 200});

--- a/test/unit/services/azuremysqldb/provision-spec.js
+++ b/test/unit/services/azuremysqldb/provision-spec.js
@@ -104,12 +104,17 @@ describe('MySqlDb - Provision - Execution', function () {
         };
 
         cp = new cmdProvision(params);
+        msRestRequest.HEAD = sinon.stub();
         
+        // check resource group existence
+        msRestRequest.HEAD.withArgs('https://management.azure.com//subscriptions/55555555-4444-3333-2222-111111111111/resourceGroups/fake-resource-group-name')
+            .yields(null, {statusCode: 404});
+
         msRestRequest.PUT = sinon.stub();
         
         // create resource group
         msRestRequest.PUT.withArgs('https://management.azure.com//subscriptions/55555555-4444-3333-2222-111111111111/resourceGroups/fake-resource-group-name')
-            .yields(null, {statusCode: 200});  
+            .yields(null, {statusCode: 200});
         
         // create server
         msRestRequest.PUT.withArgs('https://management.azure.com//subscriptions/55555555-4444-3333-2222-111111111111/resourceGroups/fake-resource-group-name/providers/Microsoft.DBforMySQL/servers/fake-server-name')

--- a/test/unit/services/azurepostgresqldb/provision-spec.js
+++ b/test/unit/services/azurepostgresqldb/provision-spec.js
@@ -105,6 +105,12 @@ describe('PostgreSqlDb - Provision - Execution', function () {
 
         cp = new cmdProvision(params);
         
+        msRestRequest.HEAD = sinon.stub();
+        
+        // check resource group existence
+        msRestRequest.HEAD.withArgs('https://management.azure.com//subscriptions/55555555-4444-3333-2222-111111111111/resourceGroups/fake-resource-group-name')
+            .yields(null, {statusCode: 404}); 
+
         msRestRequest.PUT = sinon.stub();
         
         // create resource group

--- a/test/unit/services/azurerediscache/provision-spec.js
+++ b/test/unit/services/azurerediscache/provision-spec.js
@@ -116,6 +116,10 @@ describe('RedisCache - Provision - Execution - Cache that doesn\'t previsouly ex
         };
         cp = new cmdProvision(validParams);
         
+        msRestRequest.HEAD = sinon.stub();
+        msRestRequest.HEAD.withArgs('https://management.azure.com//subscriptions/55555555-4444-3333-2222-111111111111/resourceGroups/redisResourceGroup')
+          .yields(null, {statusCode: 404});
+
         msRestRequest.PUT = sinon.stub();
         msRestRequest.PUT.withArgs('https://management.azure.com//subscriptions/55555555-4444-3333-2222-111111111111/resourceGroups/redisResourceGroup')
           .yields(null, {statusCode: 200});

--- a/test/unit/services/azureservicebus/provision-spec.js
+++ b/test/unit/services/azureservicebus/provision-spec.js
@@ -112,6 +112,10 @@ describe('ServiceBus', function() {
         msRestRequest.GET = sinon.stub();
         msRestRequest.GET.withArgs('https://management.azure.com//subscriptions/55555555-4444-3333-2222-111111111111/resourceGroups/mysbtest/providers/Microsoft.ServiceBus/namespaces/mysb')
           .yields(null, {statusCode: 404});
+        
+        msRestRequest.HEAD = sinon.stub();
+        msRestRequest.HEAD.withArgs('https://management.azure.com//subscriptions/55555555-4444-3333-2222-111111111111/resourceGroups/mysbtest')
+          .yields(null, {statusCode: 404});
           
         msRestRequest.PUT = sinon.stub();
         msRestRequest.PUT.withArgs('https://management.azure.com//subscriptions/55555555-4444-3333-2222-111111111111/resourceGroups/mysbtest')

--- a/test/unit/services/azuresqldb/provision-spec.js
+++ b/test/unit/services/azuresqldb/provision-spec.js
@@ -226,12 +226,17 @@ describe('SqlDb - Provision - Execution (allow to create server)', function () {
         cp = new cmdProvision(params);
         cp.fixupParameters();
         
+        msRestRequest.HEAD = sinon.stub();
         msRestRequest.PUT = sinon.stub();
         msRestRequest.GET = sinon.stub();
         
+        // check resource group existence
+        msRestRequest.HEAD.withArgs('https://management.azure.com//subscriptions/55555555-4444-3333-2222-111111111111/resourceGroups/fake-resource-group-name')
+            .yields(null, {statusCode: 404});
+            
         // create resource group
         msRestRequest.PUT.withArgs('https://management.azure.com//subscriptions/55555555-4444-3333-2222-111111111111/resourceGroups/fake-resource-group-name')
-            .yields(null, {statusCode: 200});  
+            .yields(null, {statusCode: 200});
         
         // create server
         msRestRequest.PUT.withArgs('https://management.azure.com//subscriptions/55555555-4444-3333-2222-111111111111/resourceGroups/fake-resource-group-name/providers/Microsoft.Sql/servers/fake-server-name')

--- a/test/unit/services/azurestorage/provision-spec.js
+++ b/test/unit/services/azurestorage/provision-spec.js
@@ -129,6 +129,10 @@ describe('Storage', function() {
           msRestRequest.POST = sinon.stub();
           msRestRequest.POST.withArgs('https://management.azure.com//subscriptions/55555555-4444-3333-2222-111111111111/providers/Microsoft.Storage/checkNameAvailability')
             .yields(null, {statusCode: 200}, {nameAvailable: true});
+          
+          msRestRequest.HEAD = sinon.stub();
+          msRestRequest.HEAD.withArgs('https://management.azure.com//subscriptions/55555555-4444-3333-2222-111111111111/resourceGroups/test031702')
+            .yields(null, {statusCode: 404});
             
           msRestRequest.PUT = sinon.stub();
           msRestRequest.PUT.withArgs('https://management.azure.com//subscriptions/55555555-4444-3333-2222-111111111111/resourceGroups/test031702')

--- a/test/unit/services/mockingHelper.js
+++ b/test/unit/services/mockingHelper.js
@@ -1,16 +1,17 @@
 var msRestRequest = require('../../../lib/common/msRestRequest');
 
-var originGet, originPut, originPost, originDelete;
+var originHead, originGet, originPut, originPost, originDelete;
 
 module.exports.backup = function(){
+  originHead = msRestRequest.HEAD;
   originGet = msRestRequest.GET;
   originPut = msRestRequest.PUT;
   originPost = msRestRequest.POST;
   originDelete = msRestRequest.DELETE;
-  
 };
 
 module.exports.restore = function(){
+  msRestRequest.HEAD = originHead;
   msRestRequest.GET = originGet;
   msRestRequest.PUT = originPut;
   msRestRequest.POST = originPost;


### PR DESCRIPTION
…urce to be in different locations)

If the resource group already exists, and the specified location for service is different from the location of resource group, the creation of the service will fail. Because the broker assumes the resource group is not existed, the creation of resource group might trigger an location conflict error. 

Solution:
Before calling createOrUpdate a resource group, check if the group exists or not.