### PR TITLE
mssql: add option to create server connection policy

### DIFF
--- a/docs/azure-mysql-db.md
+++ b/docs/azure-mysql-db.md
@@ -187,10 +187,18 @@
     "mysqlServerFullyQualifiedDomainName": "mysqlservera.mysql.database.azure.com",
     "administratorLogin": "ulrich",
     "administratorLoginPassword": "u1r8chP@ss",
-    "jdbcUrl": "jdbc:mysql://mysqlservera.mysql.database.azure.com:3306/mysqldba?user=<administratorLogin>&password=<administratorLoginPassword>&verifyServerCertificate=true&useSSL=true&requireSSL=false"
+    "jdbcUrl": "jdbc:mysql://mysqlservera.mysql.database.azure.com:3306/mysqldba?user=<administratorLogin>&password=<administratorLoginPassword>&verifyServerCertificate=true&useSSL=true&requireSSL=false",
+    "hostname": "mysqlservera.mysql.database.azure.com",
+    "port": 3306,
+    "name": "mysqldba",
+    "username": "ulrich", 
+    "password": "u1r8chP@ss",
+    "uri": "mysql://ulrich@mysqlservera:u1r8chP@ss@mysqlservera.mysql.database.azure.com:3306/mysqldba?ssl=true"
   }
 
   ```
+  
+  >**NOTE:** The part `hostname` - `uri` is compatible with [Cloud Foundry MySQL Release](https://github.com/cloudfoundry/cf-mysql-release).
   
 ## Unbinding
 

--- a/docs/azure-mysql-db.md
+++ b/docs/azure-mysql-db.md
@@ -90,7 +90,7 @@
           "properties": {
               "version": "5.6" | "5.7",
               "sslEnforcement": "Enabled" | "Disabled",
-              "storageMB": 51200 | 179200 | 307200 | ... | 947200, // 51200, 51200+128000*1, 51200+128000*2 ... 51200+128000*3
+              "storageMB": 51200 | 179200 | 307200 | ... | 1075200, // 51200, 51200+128000*1, 51200+128000*2 ... 51200+128000*8
               "administratorLogin": "<server-admin-name>",
               "administratorLoginPassword": "<server-admin-password>"
           }

--- a/docs/azure-postgresql-db.md
+++ b/docs/azure-postgresql-db.md
@@ -83,7 +83,7 @@
           "properties": {
               "version": "9.5" | "9.6",
               "sslEnforcement": "Enabled" | "Disabled",
-              "storageMB": 51200 | 179200 | 307200 | ... | 947200, // 51200, 51200+128000*1, 51200+128000*2 ... 51200+128000*3
+              "storageMB": 51200 | 179200 | 307200 | ... | 1075200, // 51200, 51200+128000*1, 51200+128000*2 ... 51200+128000*8
               "administratorLogin": "<server-admin-name>",
               "administratorLoginPassword": "<server-admin-password>"
           }

--- a/docs/azure-postgresql-db.md
+++ b/docs/azure-postgresql-db.md
@@ -180,10 +180,18 @@
     "postgresqlServerFullyQualifiedDomainName": "postgresqlservera.postgres.database.azure.com",
     "administratorLogin": "ulrich",
     "administratorLoginPassword": "u1r8chP@ss",
-    "jdbcUrl": "jdbc:postgresql://postgresqlservera.postgres.database.azure.com:5432/postgresqldba?user=ulrich@fake-server&password=u1r8chP@ss&ssl=true"
+    "jdbcUrl": "jdbc:postgresql://postgresqlservera.postgres.database.azure.com:5432/postgresqldba?user=ulrich@fake-server&password=u1r8chP@ss&ssl=true",
+    "hostname": "postgresqlservera.postgres.database.azure.com",
+    "port": 5432,
+    "name": "postgresqldba",
+    "username": "ulrich", 
+    "password": "u1r8chP@ss",
+    "uri": "postgres://ulrich@postgresqlservera:u1r8chP@ss@postgresqlservera.postgres.database.azure.com:5432/postgresqldba"
   }
 
   ```
+  
+  >**NOTE:** The part `hostname` - `uri` is compatible with [Cloud Foundry MySQL Release](https://github.com/cloudfoundry/cf-mysql-release).
   
 ## Unbinding
 

--- a/docs/azure-sql-db.md
+++ b/docs/azure-sql-db.md
@@ -117,11 +117,12 @@ azure-sqldb     basic*, StandardS0*, StandardS1*, StandardS2*, StandardS3*, Prem
       "properties": {
          "administratorLogin": "<sql-server-admin-name>",
          "administratorLoginPassword": "<sql-server-admin-password>"
-      }
+      },
+      "connectionPolicy": "<policy>"            // [Optional] The acceptable values are: "Default" | "Redirect" | "Proxy". See details: https://docs.microsoft.com/en-us/azure/sql-database/sql-database-connectivity-architecture
     },
-    "sqldbName": "<sql-database-name>",                         // [Required] Not more than 128 characters. Can't end with '.' or ' ', can't contain '<,>,*,%,&,:,\,/,?' or control characters.
-    "transparentDataEncryption": true | false,                  // Enable Transparent Data Encryption on the database. Defaults to false.
-    "sqldbParameters": {                                        // If you want to set more child parameters, see details here: https://msdn.microsoft.com/en-us/library/azure/mt163685.aspx
+    "sqldbName": "<sql-database-name>",         // [Required] Not more than 128 characters. Can't end with '.' or ' ', can't contain '<,>,*,%,&,:,\,/,?' or control characters.
+    "transparentDataEncryption": true | false,  // Enable Transparent Data Encryption on the database. Defaults to false.
+    "sqldbParameters": {                        // If you want to set more child parameters, see details here: https://msdn.microsoft.com/en-us/library/azure/mt163685.aspx
       "properties": {
         "collation": "SQL_Latin1_General_CP1_CI_AS | <or-other-valid-sqldb-collation>"
       }

--- a/docs/azure-sql-db.md
+++ b/docs/azure-sql-db.md
@@ -118,7 +118,7 @@ azure-sqldb     basic*, StandardS0*, StandardS1*, StandardS2*, StandardS3*, Prem
          "administratorLogin": "<sql-server-admin-name>",
          "administratorLoginPassword": "<sql-server-admin-password>"
       },
-      "connectionPolicy": "<policy>"            // [Optional] The acceptable values are: "Default" | "Redirect" | "Proxy". See details: https://docs.microsoft.com/en-us/azure/sql-database/sql-database-connectivity-architecture
+      "connectionPolicy": "<policy>"            // [Optional] The acceptable values are: "Default" | "Redirect" | "Proxy". The default value is "Default". See details: https://docs.microsoft.com/en-us/azure/sql-database/sql-database-connectivity-architecture
     },
     "sqldbName": "<sql-database-name>",         // [Required] Not more than 128 characters. Can't end with '.' or ' ', can't contain '<,>,*,%,&,:,\,/,?' or control characters.
     "transparentDataEncryption": true | false,  // Enable Transparent Data Encryption on the database. Defaults to false.
@@ -274,7 +274,13 @@ azure-sqldb     basic*, StandardS0*, StandardS1*, StandardS2*, StandardS3*, Prem
     "databaseLogin": "ulrich",
     "databaseLoginPassword": "u1r8chP@ss",
     "jdbcUrl": "jdbc:sqlserver://fake-server.database.windows.net:1433;database=fake-database;user=fake-admin;password=fake-password;Encrypt=true;TrustServerCertificate=false;HostNameInCertificate=*.database.windows.net;loginTimeout=30",
-    "jdbcUrlForAuditingEnabled": "jdbc:sqlserver://fake-server.database.secure.windows.net:1433;database=fake-database;user=fake-admin;password=fake-password;Encrypt=true;TrustServerCertificate=false;HostNameInCertificate=*.database.secure.windows.net;loginTimeout=30"
+    "jdbcUrlForAuditingEnabled": "jdbc:sqlserver://fake-server.database.secure.windows.net:1433;database=fake-database;user=fake-admin;password=fake-password;Encrypt=true;TrustServerCertificate=false;HostNameInCertificate=*.database.secure.windows.net;loginTimeout=30",
+    "hostname": "fake-server.database.windows.net",
+    "port": 1433,
+    "name": "sqlDbA",
+    "username": "ulrich", 
+    "password": "u1r8chP@ss",
+    "uri": "mssql://ulrich:u1r8chP@ss@fake-server.database.windows.net:1433/sqlDbA?encrypt=true"
   }
 
   ```
@@ -288,6 +294,8 @@ azure-sqldb     basic*, StandardS0*, StandardS1*, StandardS2*, StandardS3*, Prem
       2. Follow this [doc](https://github.com/cloudfoundry/java-buildpack/blob/master/docs/jre-open_jdk_jre.md#custom-ca-certificates), fork the [official java buildpack](https://github.com/cloudfoundry/java-buildpack) and add the `cacerts`.
 
       3. Push your app with the customized buildpack in #2.
+  
+  * The part `hostname` - `uri` is compatible with the community MySQL/PostgreSQL service broker.
 
 ## Unbinding
 

--- a/docs/how-admin-deploy-the-broker.md
+++ b/docs/how-admin-deploy-the-broker.md
@@ -184,7 +184,13 @@
 
       * Modules default parameters
 
-          Default parameters can be set. Please refer the configuration files in the docs for these modules.
+          Default parameters can be set.
+          
+          1. If `Allow to Generate Names and Passwords for the Missing` set to `true`, the broker can fix those missing names and passwords in the parameters for creating service instances. Check `generated-string` in the [json examples](../examples/) for details.
+
+          1. `Default Resource Group` and `Default Location` can be set to fix missing resource group and location in the parameters for creating service instances.
+
+          1. For each service, you can set default parameters for it. The broker can fix those missing parameters in the parameters for creating service instances. Set them with `{}` if you don't require any fixing. The priority of this rule is higher than the rules above.
 
           ```
           ALLOW_TO_GENERATE_NAMES_AND_PASSWORDS_FOR_THE_MISSING: true
@@ -203,8 +209,12 @@
               }
           }'
           DEFAULT_PARAMETERS_AZURE_SERVICEBUS: '{
-              "type": "Messaging",
-              "messagingTier": "Standard"
+          }'
+          DEFAULT_PARAMETERS_AZURE_EVENTHUBS: '{
+              "eventHubProperties": {
+                  "messageRetentionInDays": 1,
+                  "partitionCount": 2
+              }
           }'
           DEFAULT_PARAMETERS_AZURE_STORAGE: '{
               "accountType": "Standard_LRS"

--- a/examples/mysqldb-example-config.json
+++ b/examples/mysqldb-example-config.json
@@ -6,7 +6,7 @@
     "mysqlServerParameters": {
         "allowMysqlServerFirewallRules": [      // [Optional] If present, ruleName, startIpAddress and endIpAddress are mandatory in every rule.
             {
-                "ruleName": "<rule-name-0>",    // // The rule name can only contain 0-9, a-z, A-Z, -, _, and cannot exceed 128 characters
+                "ruleName": "<rule-name-0>",    // The rule name can only contain 0-9, a-z, A-Z, -, _, and cannot exceed 128 characters
                 "startIpAddress": "xx.xx.xx.xx",
                 "endIpAddress": "xx.xx.xx.xx"
             },
@@ -19,12 +19,12 @@
         "properties": {
             "version": "5.6" | "5.7",
             "sslEnforcement": "Enabled" | "Disabled",
-            "storageMB": 51200 | 179200 | 307200 | ... | 947200, // 51200, 51200+128000*1, 51200+128000*2 ... 51200+128000*3
+            "storageMB": 51200 | 179200 | 307200 | ... | 1075200, // 51200, 51200+128000*1, 51200+128000*2 ... 51200+128000*8
             "administratorLogin": "<server-admin-name>",
             "administratorLoginPassword": "<server-admin-password>"
         }
     },
-    "mysqlDatabaseName": "<database-name>"      // [Required] Unique. Database name cannot be empty or null. It can contain only lowercase letters, numbers and '-', but can't start or end with '-' or have more than 63 characters. 
+    "mysqlDatabaseName": "<database-name>"      // [Required]
 }
 */
 

--- a/examples/postgresqldb-example-config.json
+++ b/examples/postgresqldb-example-config.json
@@ -19,12 +19,12 @@
         "properties": {
             "version": "9.5" | "9.6",
             "sslEnforcement": "Enabled" | "Disabled",
-            "storageMB": 51200 | 179200 | 307200 | ... | 947200, // 51200, 51200+128000*1, 51200+128000*2 ... 51200+128000*3
+            "storageMB": 51200 | 179200 | 307200 | ... | 1075200, // 51200, 51200+128000*1, 51200+128000*2 ... 51200+128000*8
             "administratorLogin": "<server-admin-name>",
             "administratorLoginPassword": "<server-admin-password>"
         }
     },
-    "postgresqlDatabaseName": "<server-name>",  // [Required] Unique. Database name cannot be empty or null. It can contain only lowercase letters, numbers and '-', but can't start or end with '-' or have more than 63 characters. 
+    "postgresqlDatabaseName": "<server-name>",  // [Required]
 }
 */
 

--- a/examples/sqldb-example-config.json
+++ b/examples/sqldb-example-config.json
@@ -19,7 +19,8 @@
       "properties": {
           "administratorLogin": "<sql-server-admin-name>",
           "administratorLoginPassword": "<sql-server-admin-password>"
-      }
+      },
+      "connectionPolicy": "<policy>"            // [Optional] The acceptable values are: "Default" | "Redirect" | "Proxy". The default value is "Default". See details: https://docs.microsoft.com/en-us/azure/sql-database/sql-database-connectivity-architecture
   },
   "sqldbName": "<sql-database-name>",           // [Required] Not more than 128 characters. Can't end with '.' or ' ', can't contain '<,>,*,%,&,:,\,/,?' or control characters.
   "transparentDataEncryption": true | false,    // Enable Transparent Data Encryption on the database. Defaults to false.

--- a/lib/common/msRestRequest.js
+++ b/lib/common/msRestRequest.js
@@ -22,7 +22,7 @@ exports.init = function(azureProperties) {
 };
     
 function msRestRequest(url, qs, method, headers, data, callback) {
-  log.debug('%s %s with body: %j', method, url, data);
+  log.debug('HTTP Request:\n  method:%s\n  url:%s\n  body: %j\n', method, url, data);
   var tokenExpired = false;
 
   _.extend(headers, {'Authorization': ''});

--- a/lib/common/msRestRequest.js
+++ b/lib/common/msRestRequest.js
@@ -22,6 +22,7 @@ exports.init = function(azureProperties) {
 };
     
 function msRestRequest(url, qs, method, headers, data, callback) {
+  log.debug('%s %s with body: %j', method, url, data);
   var tokenExpired = false;
 
   _.extend(headers, {'Authorization': ''});

--- a/lib/services/azuremysqldb/index.js
+++ b/lib/services/azuremysqldb/index.js
@@ -12,6 +12,7 @@ var cmdDeprovision = require('./cmd-deprovision');
 var cmdProvision = require('./cmd-provision');
 var cmdPoll = require('./cmd-poll');
 var mysqldbOperations = require('./client');
+var urlencode = require('urlencode');
 
 var Handlers = {};
 
@@ -122,7 +123,7 @@ Handlers.bind = function (params, next) {
   var mysqlServerName = provisioningResult.mysqlServerName;
   var mysqlDatabaseName = provisioningResult.mysqlDatabaseName;
   var administratorLogin = provisioningResult.administratorLogin;
-  var administratorLoginPassword = provisioningResult.administratorLoginPassword;
+  var administratorLoginPassword = urlencode(provisioningResult.administratorLoginPassword);
   var fqdn = provisioningResult.fullyQualifiedDomainName;
   
   // Spring Cloud Connector Support
@@ -140,6 +141,13 @@ Handlers.bind = function (params, next) {
                             administratorLogin, mysqlServerName,
                             administratorLoginPassword);
 
+  var uri = util.format('mysql://%s@%s:%s@%s:3306/%s?ssl=true',
+                        administratorLogin,
+                        mysqlServerName,
+                        administratorLoginPassword,
+                        fqdn,
+                        mysqlDatabaseName);
+
   // contents of reply.value winds up in VCAP_SERVICES
   var reply = {
     statusCode: HttpStatus.CREATED,
@@ -151,7 +159,13 @@ Handlers.bind = function (params, next) {
         mysqlServerFullyQualifiedDomainName: fqdn,
         administratorLogin: administratorLogin,
         administratorLoginPassword: administratorLoginPassword,
-        jdbcUrl: jdbcUrl
+        jdbcUrl: jdbcUrl,
+        hostname: fqdn,
+        port: 3306,
+        name: mysqlDatabaseName,
+        username: administratorLogin, 
+        password: administratorLoginPassword,
+        uri: uri
       }
     }
   };

--- a/lib/services/azurepostgresqldb/index.js
+++ b/lib/services/azurepostgresqldb/index.js
@@ -12,6 +12,7 @@ var cmdDeprovision = require('./cmd-deprovision');
 var cmdProvision = require('./cmd-provision');
 var cmdPoll = require('./cmd-poll');
 var postgresqldbOperations = require('./client');
+var urlencode = require('urlencode');
 
 var Handlers = {};
 
@@ -122,7 +123,7 @@ Handlers.bind = function (params, next) {
   var postgresqlServerName = provisioningResult.postgresqlServerName;
   var postgresqlDatabaseName = provisioningResult.postgresqlDatabaseName;
   var administratorLogin = provisioningResult.administratorLogin;
-  var administratorLoginPassword = provisioningResult.administratorLoginPassword;
+  var administratorLoginPassword = urlencode(provisioningResult.administratorLoginPassword);
   var fqdn = provisioningResult.fullyQualifiedDomainName;
   
   // Spring Cloud Connector Support
@@ -137,7 +138,14 @@ Handlers.bind = function (params, next) {
                             administratorLogin,
                             postgresqlServerName,
                             administratorLoginPassword);
-                      
+            
+  var uri = util.format('postgres://%s@%s:%s@%s:5432/%s',
+      administratorLogin,
+      postgresqlServerName,
+      administratorLoginPassword,
+      fqdn,
+      postgresqlDatabaseName);
+
   // contents of reply.value winds up in VCAP_SERVICES
   var reply = {
     statusCode: HttpStatus.CREATED,
@@ -149,7 +157,13 @@ Handlers.bind = function (params, next) {
         postgresqlServerFullyQualifiedDomainName: fqdn,
         administratorLogin: administratorLogin,
         administratorLoginPassword: administratorLoginPassword,
-        jdbcUrl: jdbcUrl
+        jdbcUrl: jdbcUrl,
+        hostname: fqdn,
+        port: 5432,
+        name: postgresqlDatabaseName,
+        username: administratorLogin,
+        password: administratorLoginPassword,
+        uri: uri
       }
     }
   };

--- a/lib/services/azuresqldb/client.js
+++ b/lib/services/azuresqldb/client.js
@@ -28,12 +28,14 @@ sqldbOperations.prototype.setParameters = function (resourceGroupName, sqlServer
 
     this.serverUrl = util.format('%s/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Sql/servers/%s',
         this.resourceManagerEndpointUrl, this.azure.subscriptionId, resourceGroupName, sqlServerName);
-    this.sqldbUrl = util.format('%s/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Sql/servers/%s/databases/%s',
-        this.resourceManagerEndpointUrl, this.azure.subscriptionId, resourceGroupName, sqlServerName, sqldbName);
-    this.firewallRuleUrl = util.format('%s/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Sql/servers/%s/firewallRules/',
-        this.resourceManagerEndpointUrl, this.azure.subscriptionId, resourceGroupName, sqlServerName);
-    this.transparentDataEncryptionUrl = util.format('%s/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Sql/servers/%s/databases/%s/transparentDataEncryption/current',
-        this.resourceManagerEndpointUrl, this.azure.subscriptionId, resourceGroupName, sqlServerName, sqldbName);
+    this.sqldbUrl = util.format('%s/databases/%s',
+        this.serverUrl, sqldbName);
+    this.firewallRuleUrl = util.format('%s/firewallRules/',
+        this.serverUrl);
+    this.transparentDataEncryptionUrl = util.format('%s/transparentDataEncryption/current',
+        this.sqldbUrl);
+    this.connectionPolicyUrl = util.format('%s/connectionPolicies/Default',
+        this.serverUrl);
 
     this.sqlServerName = sqlServerName;
     this.sqldbName = sqldbName;
@@ -321,14 +323,13 @@ sqldbOperations.prototype.createServer = function (parameters, callback) {
 
     var that = this;
 
-    // create local object in case firewall rules are present
-    var sqlServerParameters = {};
-    sqlServerParameters.tags = common.mergeTags(parameters.sqlServerParameters.tags);
-    sqlServerParameters.location = parameters.location;
-    sqlServerParameters.properties = parameters.sqlServerParameters.properties;
+    var requestBody = {};
+    requestBody.tags = common.mergeTags(parameters.sqlServerParameters.tags);
+    requestBody.location = parameters.location;
+    requestBody.properties = parameters.sqlServerParameters.properties;
 
     var headers = common.mergeCommonHeaders('sqldb client - createServer', that.standardHeaders);
-    msRestRequest.PUT(that.serverUrl, headers, sqlServerParameters, API_VERSIONS.SQL, function (err, res, body) {
+    msRestRequest.PUT(that.serverUrl, headers, requestBody, API_VERSIONS.SQL, function (err, res, body) {
         if (err) {
             log.error('sqldb client: createServer: err %j', err);
             return callback(err, null);
@@ -345,6 +346,36 @@ sqldbOperations.prototype.createServer = function (parameters, callback) {
             log.debug('sqldb client: createServer: body: %j', body);
             result.body = body;
             callback(null, result);
+        }
+    });
+
+};
+
+//https://msdn.microsoft.com/library/azure/mt604439.aspx
+sqldbOperations.prototype.createServerConnectionPolicy = function (parameters, callback) {
+
+    var that = this;
+
+    var requestBody = {
+        'location': parameters.location,
+        'properties': {
+            'connectionType': parameters.sqlServerParameters.connectionPolicy
+        }
+    };
+    
+    var headers = common.mergeCommonHeaders('sqldb client - createServerConnectionPolicy', that.standardHeaders);
+    msRestRequest.PUT(that.connectionPolicyUrl, headers, requestBody, API_VERSIONS.SQL, function (err, res, body) {
+        if (err) {
+            log.error('sqldb client: createServerConnectionPolicy: err %j', err);
+            return callback(err, null);
+        }
+        
+        common.logHttpResponse(res, 'Create SQL server connection policy', true);
+
+        if (res.statusCode !== HttpStatus.OK) {
+            return common.formatErrorFromRes(res, callback);
+        } else {
+            callback(null);
         }
     });
 

--- a/lib/services/azuresqldb/cmd-provision.js
+++ b/lib/services/azuresqldb/cmd-provision.js
@@ -177,7 +177,7 @@ var sqldbProvision = function (params) {
                 if (err) {
                     log.error('sqldb cmd-provision: final callback: err: ', err);
                 } else {
-                    log.info('sqldb cmd-provision: final callback: result: ', result);
+                    log.info('sqldb cmd-provision: final callback: result: %j', result.value);
                 }
                 next(err, result);
             });
@@ -253,6 +253,13 @@ var sqldbProvision = function (params) {
                         callback(null);
                     }
                 },
+                function (callback) {   // create connection policy
+                    if (reqParams.sqlServerParameters.connectionPolicy) {
+                        sqldbOperations.createServerConnectionPolicy(reqParams, callback);
+                    } else {
+                        callback(null);
+                    }
+                },
                 function (callback) {   // see if db exists (in the case that sql server was there already)
                     getDatabase(callback);
                 },
@@ -263,7 +270,7 @@ var sqldbProvision = function (params) {
                 if (err) {
                     log.info('sqldb cmd-provision: final callback: err: ', err);
                 } else {
-                    log.info('sqldb cmd-provision: final callback: result: ', result);
+                    log.info('sqldb cmd-provision: final callback: result: %j', result.value);
                 }
                 next(err, result);
             });

--- a/lib/services/azuresqldb/index.js
+++ b/lib/services/azuresqldb/index.js
@@ -16,6 +16,7 @@ var cmdUnbind = require('./cmd-unbind.js');
 var cmdUpdate = require('./cmd-update.js');
 var sqldbOperations = require('./client');
 var deepExtend = require('deep-extend');
+var urlencode = require('urlencode');
 
 var Handlers = {};
 
@@ -154,7 +155,11 @@ Handlers.bind = function (params, next) {
       common.handleServiceError(err, next);
     } else {
       var provisioningResult = params.provisioning_result;
-
+      var sqldbName = provisioningResult.name;
+      var sqlServerName = provisioningResult.sqlServerName;
+      var databaseLogin = result.databaseLogin;
+      var databaseLoginPassword = urlencode(result.databaseLoginPassword);
+            
       var fqdn = provisioningResult.fullyQualifiedDomainName;
       // Spring Cloud Connector Support
       var jdbcUrlTemplate = 'jdbc:sqlserver://%s:1433;' +
@@ -168,18 +173,24 @@ Handlers.bind = function (params, next) {
 
       var jdbcUrl = util.format(jdbcUrlTemplate,
                                 fqdn,
-                                provisioningResult.name,
-                                result.databaseLogin,
-                                result.databaseLoginPassword,
+                                sqldbName,
+                                databaseLogin,
+                                databaseLoginPassword,
                                 fqdn.replace(/.+\.database/, '*.database'));
 
       // Differences between auditing enabled and disabled: https://docs.microsoft.com/en-us/azure/sql-database/sql-database-auditing-and-dynamic-data-masking-downlevel-clients
       var jdbcUrlForAuditingEnabled = util.format(jdbcUrlTemplate,
-                                fqdn.replace(/\.database/, '.database.secure'),
-                                provisioningResult.name,
-                                result.databaseLogin,
-                                result.databaseLoginPassword,
-                                fqdn.replace(/.+\.database/, '*.database.secure'));
+                                                  fqdn.replace(/\.database/, '.database.secure'),
+                                                  sqldbName,
+                                                  databaseLogin,
+                                                  databaseLoginPassword,
+                                                  fqdn.replace(/.+\.database/, '*.database.secure'));
+
+      var uri = util.format('mssql://%s:%s@%s:1433/%s?encrypt=true',
+                            databaseLogin,
+                            databaseLoginPassword,
+                            fqdn,
+                            sqldbName);
 
       // contents of reply.value winds up in VCAP_SERVICES
       var reply = {
@@ -187,13 +198,19 @@ Handlers.bind = function (params, next) {
         code: HttpStatus.getStatusText(HttpStatus.CREATED),
         value: {
           credentials: {
-            sqldbName: provisioningResult.name,
-            sqlServerName: provisioningResult.sqlServerName,
+            sqldbName: sqldbName,
+            sqlServerName: sqlServerName,
             sqlServerFullyQualifiedDomainName: fqdn,
-            databaseLogin: result.databaseLogin,
-            databaseLoginPassword: result.databaseLoginPassword,
+            databaseLogin: databaseLogin,
+            databaseLoginPassword: databaseLoginPassword,
             jdbcUrl: jdbcUrl,
-            jdbcUrlForAuditingEnabled: jdbcUrlForAuditingEnabled
+            jdbcUrlForAuditingEnabled: jdbcUrlForAuditingEnabled,
+            hostname: fqdn,
+            port: 1433,
+            name: sqldbName,
+            username: databaseLogin, 
+            password: databaseLoginPassword,
+            uri: uri
           }
         }
       };

--- a/test/integration/submatrix/mysqldb.js
+++ b/test/integration/submatrix/mysqldb.js
@@ -53,7 +53,13 @@ azuremysqldb = {
     'mysqlServerName': mysqlServerName,
     'mysqlServerFullyQualifiedDomainName': '<string>',
     'mysqlDatabaseName': 'testmysqldb',
-    'jdbcUrl': '<string>'
+    'jdbcUrl': '<string>',
+    'hostname': '<string>',
+    'port': 3306,
+    'name': '<string>',
+    'username': '<string>',
+    'password': '<string>',
+    'uri': '<string>'
   },
   e2e: true
 };

--- a/test/integration/submatrix/postgresqldb.js
+++ b/test/integration/submatrix/postgresqldb.js
@@ -53,7 +53,13 @@ azurepostgresqldb = {
     'postgresqlServerName': postgresqlServerName,
     'postgresqlDatabaseName': 'testpgsqldb',
     'postgresqlServerFullyQualifiedDomainName': '<string>',
-    'jdbcUrl': '<string>'
+    'jdbcUrl': '<string>',
+    'hostname': '<string>',
+    'port': 5432,
+    'name': '<string>',
+    'username': '<string>',
+    'password': '<string>',
+    'uri': '<string>'
   },
   e2e: true
 };

--- a/test/integration/submatrix/sqldb.js
+++ b/test/integration/submatrix/sqldb.js
@@ -64,7 +64,13 @@ azuresqldb = {
     'sqlServerFullyQualifiedDomainName': '<string>',
     'sqldbName': sqldbName,
     'jdbcUrl': '<string>',
-    'jdbcUrlForAuditingEnabled': '<string>'
+    'jdbcUrlForAuditingEnabled': '<string>',
+    'hostname': '<string>',
+    'port': 1433,
+    'name': '<string>',
+    'username': '<string>',
+    'password': '<string>',
+    'uri': '<string>'
   },
   e2e: false,
   updateParameters: {
@@ -106,7 +112,8 @@ azuresqldb = {
       },
       'tags': {
         'foo': 'bar'
-      }
+      },
+      'connectionPolicy': 'Proxy'
     },
     'sqldbName': sqldbName,
     'transparentDataEncryption': true,
@@ -127,7 +134,13 @@ azuresqldb = {
     'sqlServerFullyQualifiedDomainName': '<string>',
     'sqldbName': sqldbName,
     'jdbcUrl': '<string>',
-    'jdbcUrlForAuditingEnabled': '<string>'
+    'jdbcUrlForAuditingEnabled': '<string>',
+    'hostname': '<string>',
+    'port': 1433,
+    'name': '<string>',
+    'username': '<string>',
+    'password': '<string>',
+    'uri': '<string>'
   },
   e2e: true
 };

--- a/test/integration/test-matrix2.js
+++ b/test/integration/test-matrix2.js
@@ -59,7 +59,13 @@ azuresqldb = {
     'sqlServerFullyQualifiedDomainName': '<string>',
     'sqldbName': sqldbName,
     'jdbcUrl': '<string>',
-    'jdbcUrlForAuditingEnabled': '<string>'
+    'jdbcUrlForAuditingEnabled': '<string>',
+    'hostname': '<string>',
+    'port': 1433,
+    'name': '<string>',
+    'username': '<string>',
+    'password': '<string>',
+    'uri': '<string>'
   },
   e2e: true
 };

--- a/test/unit/services/azureeventhubs/fixParameters-spec.js
+++ b/test/unit/services/azureeventhubs/fixParameters-spec.js
@@ -1,0 +1,48 @@
+/* jshint camelcase: false */
+/* jshint newcap: false */
+/* global describe, before, it */
+
+var should = require('should');
+var azureeventhubs = require('../../../../lib/services/azureeventhubs/');
+
+describe('Eventhubs', function() {
+
+  describe('fixParameters', function() {
+    before(function() {
+      process.env['ALLOW_TO_GENERATE_NAMES_AND_PASSWORDS_FOR_THE_MISSING'] = 'true';
+      process.env['DEFAULT_RESOURCE_GROUP'] = 'azure-service-broker';
+      process.env['DEFAULT_LOCATION'] = 'eastus';
+      process.env['DEFAULT_PARAMETERS_AZURE_EVENTHUBS'] = '{\
+        "eventHubProperties": {\
+            "messageRetentionInDays": 1,\
+            "partitionCount": 2\
+        }\
+      }';
+    });
+    
+    var paramsToValidate = ['resourceGroup', 'namespaceName', 'location', 'eventHubProperties'];
+      
+    describe('When no parameter passed in', function() {
+      var parameters = {};
+      
+      it('should fix the parameters', function() {
+        var fixedParams = azureeventhubs.fixParameters(parameters);
+        paramsToValidate.forEach(function(param){
+          should.exist(fixedParams[param]);
+        });
+      });
+    });
+    
+    describe('When part of parameters passed in: namespaceName', function() {
+      var parameters = {'namespaceName': 'fake-name'};
+      
+      it('should fix the parameters', function() {
+        var fixedParams = azureeventhubs.fixParameters(parameters);
+        paramsToValidate.forEach(function(param){
+          should.exist(fixedParams[param]);
+        });
+        fixedParams.namespaceName.should.equal('fake-name');
+      });
+    });
+  });
+});

--- a/test/unit/services/azurerediscache/index-spec.js
+++ b/test/unit/services/azurerediscache/index-spec.js
@@ -65,11 +65,13 @@ describe('RedisCache - Index - Provision', function() {
             }
         };
         sinon.stub(redisClient, 'provision').yields(null, provisioningResult);
+        sinon.stub(resourceGroupClient, 'checkExistence').yields(null, false);
         sinon.stub(resourceGroupClient, 'createOrUpdate').yields(null);
     });
     
     after(function() {
         redisClient.provision.restore();
+        resourceGroupClient.checkExistence.restore();
         resourceGroupClient.createOrUpdate.restore();
     });
     

--- a/test/unit/services/azureservicebus/provision-spec.js
+++ b/test/unit/services/azureservicebus/provision-spec.js
@@ -58,7 +58,11 @@ describe('ServiceBus', function() {
         msRestRequest.GET = sinon.stub();
         msRestRequest.GET.withArgs('https://management.azure.com//subscriptions/55555555-4444-3333-2222-111111111111/resourceGroups/mysbtest/providers/Microsoft.ServiceBus/namespaces/mysb')
           .yields(null, {statusCode: 404});
-          
+
+        msRestRequest.HEAD = sinon.stub();
+        msRestRequest.HEAD.withArgs('https://management.azure.com//subscriptions/55555555-4444-3333-2222-111111111111/resourceGroups/mysbtest')
+          .yields(null, {statusCode: 404});
+
         msRestRequest.PUT = sinon.stub();
         msRestRequest.PUT.withArgs('https://management.azure.com//subscriptions/55555555-4444-3333-2222-111111111111/resourceGroups/mysbtest')
           .yields(null, {statusCode: 200});

--- a/test/unit/services/azuresqldb/provision-spec.js
+++ b/test/unit/services/azuresqldb/provision-spec.js
@@ -38,6 +38,7 @@ describe('SqlDb - Provision - PreConditions', function () {
                             administratorLogin: 'fake-server-name',
                             administratorLoginPassword: 'c1oudc0w'
                         },
+                        connectionPolicy: 'Proxy',
                         tags: {
                             foo: 'bar'
                         }
@@ -244,6 +245,10 @@ describe('SqlDb - Provision - Execution (allow to create server)', function () {
         
         // create firewall rule
         msRestRequest.PUT.withArgs('https://management.azure.com//subscriptions/55555555-4444-3333-2222-111111111111/resourceGroups/fake-resource-group-name/providers/Microsoft.Sql/servers/fake-server-name/firewallRules/newrule')
+            .yields(null, {statusCode: 200});
+        
+        // create connection policy
+        msRestRequest.PUT.withArgs('https://management.azure.com//subscriptions/55555555-4444-3333-2222-111111111111/resourceGroups/fake-resource-group-name/providers/Microsoft.Sql/servers/fake-server-name/connectionPolicies/Default')
             .yields(null, {statusCode: 200});
         
         // create db

--- a/test/unit/services/azurestorage/provision-spec.js
+++ b/test/unit/services/azurestorage/provision-spec.js
@@ -59,7 +59,11 @@ describe('Storage', function() {
           msRestRequest.POST = sinon.stub();
           msRestRequest.POST.withArgs('https://management.azure.com//subscriptions/55555555-4444-3333-2222-111111111111/providers/Microsoft.Storage/checkNameAvailability')
             .yields(null, {statusCode: 200}, {nameAvailable: true});
-            
+          
+          msRestRequest.HEAD = sinon.stub();
+          msRestRequest.HEAD.withArgs('https://management.azure.com//subscriptions/55555555-4444-3333-2222-111111111111/resourceGroups/test031702')
+            .yields(null, {statusCode: 404});
+
           msRestRequest.PUT = sinon.stub();
           msRestRequest.PUT.withArgs('https://management.azure.com//subscriptions/55555555-4444-3333-2222-111111111111/resourceGroups/test031702')
             .yields(null, {statusCode: 200});

--- a/test/utils/azuremysqldbClient.js
+++ b/test/utils/azuremysqldbClient.js
@@ -1,6 +1,5 @@
 var common = require('../../lib/common');
 var statusCode = require('./statusCode');
-var supportedEnvironments = require('./supportedEnvironments');
 var async = require('async');
 var util = require('util');
 var mysql = require('mysql2');
@@ -19,15 +18,8 @@ module.exports = function(environment) {
     if (retryCount > 0) {
       log.info('Retry E2E test, retryCount: %d', retryCount);
     }
-    
-    var serverSuffix = supportedEnvironments[environment]['mysqlServerEndpointSuffix'];
-    var config = {
-        host: credential.mysqlServerName + serverSuffix,
-        user: util.format('%s@%s',  credential.administratorLogin, credential.mysqlServerName),
-        password: credential.administratorLoginPassword,
-        database: credential.mysqlDatabaseName,
-        port: 3306
-    };
+
+    var uri = credential.uri;
     
     function nextStep(err, message, callback) {
       if (err) {
@@ -41,12 +33,12 @@ module.exports = function(environment) {
 
     var tableName = 'testtable' + Math.floor((Math.random() * 10000) + 1);
     
-    var conn = mysql.createConnection(config);
+    var conn = mysql.createConnection(uri);
     async.waterfall([
       function(callback) {
-        log.debug('Connecting to MySQL server %s%s', credential.mysqlServerName, serverSuffix);
+        log.debug('Connecting to MySQL DB with uri: %s', uri);
         conn.connect(function(err) {
-          var message = 'The MySQL server can %sbe connected.';
+          var message = 'The MySQL DB can %sbe connected.';
           nextStep(err, message, callback);
         });
       },

--- a/test/utils/azurepostgresqldbClient.js
+++ b/test/utils/azurepostgresqldbClient.js
@@ -1,8 +1,6 @@
 var common = require('../../lib/common');
 var statusCode = require('./statusCode');
-var supportedEnvironments = require('./supportedEnvironments');
 var async = require('async');
-var util = require('util');
 
 module.exports = function(environment) {
   var clientName = 'azurepostgresqldbClient';
@@ -10,17 +8,8 @@ module.exports = function(environment) {
 
   this.validateCredential = function(credential, next) {
     var pg = require('pg');
-    
-    var serverSuffix = supportedEnvironments[environment]['postgresqlServerEndpointSuffix'];
-    var config = {
-      user: util.format('%s@%s',  credential.administratorLogin, credential.postgresqlServerName),
-      database: credential.postgresqlDatabaseName,
-      password: credential.administratorLoginPassword,
-      host: credential.postgresqlServerName + serverSuffix,
-      port: 5432,
-      max: 10, // max number of clients in the pool
-      idleTimeoutMillis: 30000, // how long a client is allowed to remain idle before being closed
-    };
+
+    var uri = credential.uri;
     
     function nextStep(err, message, callback) {
       if (err) {
@@ -32,10 +21,10 @@ module.exports = function(environment) {
       }
     }
 
-    var client = new pg.Client(config);
+    var client = new pg.Client(uri);
     async.waterfall([
       function(callback) {
-        log.debug('Connecting to PostgreSQL DB %s%s', credential.postgresqlServerName, serverSuffix);
+        log.debug('Connecting to PostgreSQL DB with uri: %s', uri);
         client.connect(function(err) {
           var message = 'The PostgreSQL DB can %sbe connected.';
           nextStep(err, message, callback);

--- a/test/utils/azuresqldbClient.js
+++ b/test/utils/azuresqldbClient.js
@@ -6,6 +6,7 @@ var msRestRequest = require('../../lib/common/msRestRequest');
 var util = require('util');
 var _ = require('underscore');
 var broker = require('../../brokerserver');
+var mssql = require('mssql');
 
 module.exports = function(environment) {
   var clientName = 'azuresqldbClient';
@@ -35,6 +36,14 @@ module.exports = function(environment) {
 
     var connection;
     async.waterfall([
+      function(callback) {
+        log.debug('Connecting to SQL server with uri: %s', credential.uri);
+        var conn = mssql.connect(credential.uri, function(err) {
+          conn.close();
+          var message = 'The SQL Database can %sbe connected with uri.';
+          nextStep(err, message, callback);
+        });
+      },
       function(callback) {
         log.debug('Connecting to SQL server %s%s and database %s', credential.sqlServerName, serverSuffix, credential.sqldbName);
         connection = new Connection(config);


### PR DESCRIPTION
* add option to create sql server connection policy
* keep the credentials of mssql/mysql/postgresql compatible with https://github.com/cloudfoundry/cf-mysql-release
* add unit test for event hubs fixing parameters
* refine doc: add more description to default parameters; fix max size of mysql/pgsql db
