### PR TITLE
delete useless 'requestedServiceObjectiveId' in the plans of sqldb

### DIFF
--- a/lib/services/azuresqldb/cmd-provision.js
+++ b/lib/services/azuresqldb/cmd-provision.js
@@ -76,7 +76,6 @@ var sqldbProvision = function (params) {
                 params.parameters.sqldbParameters.properties.createMode = item.metadata.details.createMode;
                 params.parameters.sqldbParameters.properties.edition = item.metadata.details.edition;
                 params.parameters.sqldbParameters.properties.requestedServiceObjectiveName = item.metadata.details.requestedServiceObjectiveName;
-                //params.parameters.sqldbParameters.properties.requestedServiceObjectiveId = item.metadata.details.requestedServiceObjectiveId;
             }
         });
 

--- a/lib/services/azuresqldb/service.json
+++ b/lib/services/azuresqldb/service.json
@@ -69,8 +69,7 @@
                     "createMode": "Default",
                     "edition": "Standard",
                     "maxSizeBytes": "268435456000",
-                    "requestedServiceObjectiveName": "S0",
-                    "requestedServiceObjectiveId": "f1173c43-91bd-4aaa-973c-54e79e15235b"
+                    "requestedServiceObjectiveName": "S0"
                 }
             }
         }, {
@@ -100,8 +99,7 @@
                     "createMode": "Default",
                     "edition": "Standard",
                     "maxSizeBytes": "268435456000",
-                    "requestedServiceObjectiveName": "S1",
-                    "requestedServiceObjectiveId": "1b1ebd4d-d903-4baa-97f9-4ea675f5e928"
+                    "requestedServiceObjectiveName": "S1"
                 }
             }
         }, {


### PR DESCRIPTION
The 'requestedServiceObjectiveId' is useless and never used.

ref: http://blog.itaysk.com/2015/09/04/create-sql-db-from-arm-template-requestedserviceobjectiveid