### PR TITLE
uri encoding changes

### DIFF
--- a/lib/services/azurepostgresqldb/index.js
+++ b/lib/services/azurepostgresqldb/index.js
@@ -12,7 +12,6 @@ var cmdDeprovision = require('./cmd-deprovision');
 var cmdProvision = require('./cmd-provision');
 var cmdPoll = require('./cmd-poll');
 var postgresqldbOperations = require('./client');
-var urlencode = require('urlencode');
 
 var Handlers = {};
 
@@ -123,9 +122,10 @@ Handlers.bind = function (params, next) {
   var postgresqlServerName = provisioningResult.postgresqlServerName;
   var postgresqlDatabaseName = provisioningResult.postgresqlDatabaseName;
   var administratorLogin = provisioningResult.administratorLogin;
-  var administratorLoginPassword = urlencode(provisioningResult.administratorLoginPassword);
+  var administratorLoginPassword = provisioningResult.administratorLoginPassword;
   var fqdn = provisioningResult.fullyQualifiedDomainName;
-  
+  // server login is user@server
+  var serverLogin = administratorLogin+'@'+postgresqlServerName;
   // Spring Cloud Connector Support
   var jdbcUrlTemplate = 'jdbc:postgresql://%s:5432' + 
                         '/%s' +
@@ -137,15 +137,16 @@ Handlers.bind = function (params, next) {
                             postgresqlDatabaseName,
                             administratorLogin,
                             postgresqlServerName,
-                            administratorLoginPassword);
-            
-  var uri = util.format('postgres://%s@%s:%s@%s:5432/%s',
-      administratorLogin,
-      postgresqlServerName,
-      administratorLoginPassword,
+                            encodeURIComponent(administratorLoginPassword));
+  // encode the URI components that can contain reserved "delimiter" characters
+  // see: https://tools.ietf.org/html/rfc3986#section-2.2      
+  var uriUser = encodeURIComponent(serverLogin);
+  var uriPassword =  encodeURIComponent(administratorLoginPassword);
+  var uri = util.format('postgres://%s:%s@%s:5432/%s',
+      uriUser,
+      uriPassword,
       fqdn,
       postgresqlDatabaseName);
-
   // contents of reply.value winds up in VCAP_SERVICES
   var reply = {
     statusCode: HttpStatus.CREATED,
@@ -161,7 +162,9 @@ Handlers.bind = function (params, next) {
         hostname: fqdn,
         port: 5432,
         name: postgresqlDatabaseName,
-        username: administratorLogin,
+        // TODO: if username and password are the login credentials, then
+        // username should be user@server
+        username: serverLogin,
         password: administratorLoginPassword,
         uri: uri
       }


### PR DESCRIPTION
Changes to address connection issues described in Errors connecting to Azure PostgreSQL service when using VCAP_SERVICES parameters #140

Key changes:
- Encode the individual URI Components using encodeURIComponent() 
- Set username property to username@servername
- Replace global encoding of password with encoding only when in a URL/URI context

**Note: it looks like similar changes may be needed for the [MySQL](https://github.com/Azure/meta-azure-service-broker/blob/master/lib/services/azuremysqldb/index.js) service as well, since the logic in the bind operation there looks similar.**