### PR TITLE
Fix: stop handling the request when failing to authorize

### DIFF
--- a/lib/broker/v2/api-handlers.js
+++ b/lib/broker/v2/api-handlers.js
@@ -51,7 +51,7 @@ Handlers.authenticate = function(credentials) {
 
     log.error('Invalid auth credentials for requests.');
     res.send(HttpStatus.UNAUTHORIZED, {});
-    return next();
+    return next(false);
   };
 };
 


### PR DESCRIPTION
https://github.com/Azure/meta-azure-service-broker/blob/master/lib/broker/v2/api-handlers.js#L54
Though “401 UNAUTHORIZED” is responsed to CC at the line above, it wouldn’t stop handling the request if it just returns next() here.