### PR TITLE
fix SQL injection issue

### DIFF
--- a/lib/broker/db/sqlserver/index.js
+++ b/lib/broker/db/sqlserver/index.js
@@ -33,7 +33,7 @@ Database.prototype.createSchema = function(callback) {
       log.error('Failed to read the schema: %j', err);
       callback(err);
     }
-    sqlserver.executeSql(db.dbConfig, data, function(err, data) {
+    sqlserver.executeSql(db.dbConfig, data, {}, function(err, data) {
       if (err) {
         log.error('Failed to execute sql: %j', err);
         callback(err);
@@ -72,13 +72,25 @@ Database.prototype.createServiceInstance = function(params, callback) {
   parameters = encryptionHelper.encryptText(db.encryptionKey, params.instance_id, parameters);
 
   var sql = util.format(
-    'INSERT INTO %s(azureInstanceId, status, instanceId, serviceId, planId, organizationGuid, spaceGuid, parameters, lastOperation) values (\'%s\', \'%s\', \'%s\', \'%s\', \'%s\', \'%s\', \'%s\', @parameters, \'%s\')',
-    db.instanceTableName,
-    azureInstanceId, 'pending', instanceId, serviceId, planId,
-    organizationGuid, spaceGuid, 'provision');
-  log.debug(sql);
+    'INSERT INTO %s (azureInstanceId, status, instanceId, serviceId, planId, organizationGuid, spaceGuid, parameters, lastOperation) ' +
+      'values (@azureInstanceId, @status, @instanceId, @serviceId, @planId, @organizationGuid, @spaceGuid, @parameters, @lastOperation)',
+    db.instanceTableName
+  );
+    
+  var sqlParameters = {
+    'azureInstanceId': azureInstanceId,
+    'status': 'pending',
+    'instanceId': instanceId,
+    'serviceId': serviceId,
+    'planId': planId,
+    'organizationGuid': organizationGuid,
+    'spaceGuid': spaceGuid,
+    'parameters': parameters,
+    'lastOperation': 'provision'
+  };
+  log.debug(sql, sqlParameters);
 
-  sqlserver.executeSqlWithParameters(db.dbConfig, sql, parameters, function(err, data) {
+  sqlserver.executeSql(db.dbConfig, sql, sqlParameters, function(err, data) {
     if (err) {
       if (err.name == 'RequestError' && err.message.startsWith('Violation of UNIQUE KEY constraint')) {
         return common.handleServiceErrorEx(HttpStatus.CONFLICT,
@@ -97,30 +109,50 @@ Database.prototype.createServiceInstance = function(params, callback) {
 
 Database.prototype.updateServiceInstanceDeprovisioningResult = function(instanceId, lastOperation, provisioningResult, callback) {
   provisioningResult = encryptionHelper.encryptText(this.encryptionKey, instanceId, provisioningResult);
-  var params = util.format('lastOperation=\'%s\', provisioningResult=\'%s\'', lastOperation, provisioningResult);
+  var params = {
+    'lastOperation': lastOperation,
+    'provisioningResult': provisioningResult
+  };
   this.updateServiceInstance(instanceId, params, callback);
 };
 
 Database.prototype.updateServiceInstanceProvisioningPendingResult = function(instanceId, provisioningResult, callback) {
   provisioningResult = encryptionHelper.encryptText(this.encryptionKey, instanceId, provisioningResult);
-  var params = util.format('provisioningResult=\'%s\'', provisioningResult);
+  var params = {
+    'provisioningResult': provisioningResult
+  };
   this.updateServiceInstance(instanceId, params, callback);
 };
 
 Database.prototype.updateServiceInstanceProvisioningSuccessResult = function(instanceId, provisioningResult, callback) {
   provisioningResult = encryptionHelper.encryptText(this.encryptionKey, instanceId, provisioningResult);
-  var params = util.format('provisioningResult=\'%s\', status=\'success\'', provisioningResult);
+  var params = {
+    'provisioningResult': provisioningResult,
+    'status': 'success'
+  };
   this.updateServiceInstance(instanceId, params, callback);
 };
 
 Database.prototype.updateServiceInstance = function(instanceId, params, callback) {
   var db = this;
 
+  var attrsToUpdate = '';
+  for (var key in params) {
+    if (params.hasOwnProperty(key)) {
+      attrsToUpdate += util.format('%s=@%s, ', key, key);
+    }
+  }
   var sql = util.format(
-    'UPDATE %s SET %s, timestamp=getdate() where instanceId=\'%s\'',
-    db.instanceTableName, params, instanceId);
-  log.debug(sql);
-  sqlserver.executeSql(db.dbConfig, sql, function(err, data) {
+    'UPDATE %s SET %stimestamp=getdate() where instanceId=@instanceId',
+    db.instanceTableName,
+    attrsToUpdate
+  );
+  var sqlParameters = {};
+  sqlParameters = _.extend(sqlParameters, params);
+  sqlParameters = _.extend(sqlParameters, {'instanceId': instanceId});
+
+  log.debug(sql, sqlParameters);
+  sqlserver.executeSql(db.dbConfig, sql, sqlParameters, function(err, data) {
     if (err) {
       return common.handleServiceErrorEx(HttpStatus.INTERNAL_SERVER_ERROR,
         util.format('Failed in updating the record for (instanceId: %s) in the broker database. DB Error: %j', instanceId, err),
@@ -136,9 +168,14 @@ Database.prototype.updateServiceInstance = function(instanceId, params, callback
 Database.prototype.getServiceInstances = function(callback) {
   var db = this;
 
-  var sql = util.format('SELECT * FROM %s', db.instanceTableName);
-  log.debug(sql);
-  sqlserver.executeSql(db.dbConfig, sql, function (err, result) {
+  var sql = util.format(
+    'SELECT * FROM %s',
+    db.instanceTableName
+  );
+  var sqlParameters = {
+  };
+  log.debug(sql, sqlParameters);
+  sqlserver.executeSql(db.dbConfig, sql, sqlParameters, function (err, result) {
     if (err) {
       return common.handleServiceErrorEx(HttpStatus.INTERNAL_SERVER_ERROR,
         util.format('Failed getting instances in the broker database. DB Error: %j', err), callback);
@@ -188,10 +225,16 @@ Database.prototype.deserializeRecord = function(record) {
 Database.prototype.getServiceInstance = function(instanceId, callback) {
   var db = this;
 
-  var sql = util.format('SELECT * FROM %s where instanceId=\'%s\'', db.instanceTableName, instanceId);
-  log.debug(sql);
+  var sql = util.format(
+    'SELECT * FROM %s where instanceId=@instanceId',
+    db.instanceTableName
+  );
+  var sqlParameters = {
+    'instanceId': instanceId
+  };
+  log.debug(sql, sqlParameters);
 
-  sqlserver.executeSql(db.dbConfig, sql, function(err, result) {
+  sqlserver.executeSql(db.dbConfig, sql, sqlParameters, function(err, result) {
     if (err) {
       return common.handleServiceErrorEx(HttpStatus.INTERNAL_SERVER_ERROR,
         util.format('Failed in finding the record by (instanceId: %s) in the broker database. DB Error: %j', instanceId, err),
@@ -221,17 +264,28 @@ Database.prototype.setServiceInstance = function (serviceInstance, callback) {
   provisioningResult = encryptionHelper.encryptText(db.encryptionKey, instanceId, provisioningResult);
 
   var sql = util.format(
-    'UPDATE %s SET status=\'%s\', planId=\'%s\', parameters=\'%s\', lastOperation=\'%s\', provisioningResult=\'%s\', state=\'%s\', timestamp=getdate() where instanceId=\'%s\'',
-    db.instanceTableName,
-    serviceInstance.status,
-    serviceInstance.plan_id,
-    parameters,
-    serviceInstance.last_operation,
-    provisioningResult,
-    state,
-    instanceId);
-  log.debug(sql);
-  sqlserver.executeSql(db.dbConfig, sql, function (err, data) {
+    'UPDATE %s SET' + 
+      ' status=@status,' +
+      ' planId=@planId,' + 
+      ' parameters=@parameters,' + 
+      ' lastOperation=@lastOperation,' +
+      ' provisioningResult=@provisioningResult,' +
+      ' state=@state,' +
+      ' timestamp=getdate()' +
+      ' where instanceId=@instanceId',
+    db.instanceTableName
+  );
+  var sqlParameters = {
+    'status': serviceInstance.status,
+    'planId': serviceInstance.plan_id,
+    'parameters': parameters,
+    'lastOperation': serviceInstance.last_operation,
+    'provisioningResult': provisioningResult,
+    'state': state,
+    'instanceId': instanceId
+  };
+  log.debug(sql, sqlParameters);
+  sqlserver.executeSql(db.dbConfig, sql, sqlParameters, function (err, data) {
     if (err) {
       return common.handleServiceErrorEx(HttpStatus.INTERNAL_SERVER_ERROR,
         util.format('Failed in updating the record for (instanceId: %s) in the broker database. DB Error: %j', instanceId, err),
@@ -246,9 +300,15 @@ Database.prototype.setServiceInstance = function (serviceInstance, callback) {
 Database.prototype.deleteServiceInstance = function(instanceId, callback) {
   var db = this;
 
-  var sql = util.format('DELETE FROM %s where instanceId=\'%s\'', db.instanceTableName, instanceId);
-  log.debug(sql);
-  sqlserver.executeSql(db.dbConfig, sql, function(err, data) {
+  var sql = util.format(
+    'DELETE FROM %s where instanceId=@instanceId',
+    db.instanceTableName
+  );
+  var sqlParameters = {
+    'instanceId': instanceId
+  };
+  log.debug(sql, sqlParameters);
+  sqlserver.executeSql(db.dbConfig, sql, sqlParameters, function(err, data) {
     if (err) {
       return common.handleServiceErrorEx(HttpStatus.INTERNAL_SERVER_ERROR,
         util.format('Failed in deleting the record for (instanceId: %s) from the broker database. You may need to delete this record manually. DB Error: %j.', instanceId, err),
@@ -274,10 +334,20 @@ Database.prototype.createServiceBinding = function(params, result, callback) {
   bindingResult = encryptionHelper.encryptText(db.encryptionKey, bindingId, bindingResult);
 
   var sql = util.format(
-    'INSERT INTO %s(bindingId, instanceId, serviceId, planId, parameters, bindingResult) values (\'%s\', \'%s\', \'%s\', \'%s\', @parameters, \'%s\')',
-    db.bindingTableName, bindingId, instanceId, serviceId, planId, bindingResult);
-  log.debug(sql);
-  sqlserver.executeSqlWithParameters(db.dbConfig, sql, parameters, function(err, data) {
+    'INSERT INTO %s (bindingId, instanceId, serviceId, planId, parameters, bindingResult) ' +
+      'values (@bindingId, @instanceId, @serviceId, @planId, @parameters, @bindingResult)',
+    db.bindingTableName
+  );
+  var sqlParameters = {
+    'bindingId': bindingId,
+    'instanceId': instanceId,
+    'serviceId': serviceId,
+    'planId': planId,
+    'parameters': parameters,
+    'bindingResult': bindingResult
+  };
+  log.debug(sql, sqlParameters);
+  sqlserver.executeSql(db.dbConfig, sql, sqlParameters, function(err, data) {
     if (err) {
       return common.handleServiceErrorEx(HttpStatus.INTERNAL_SERVER_ERROR,
         util.format('Failed in inserting the record (bindingId: %s) for(instanceId: %s) in broker database. DB Error: %j', bindingId, instanceId, err),
@@ -292,10 +362,16 @@ Database.prototype.createServiceBinding = function(params, result, callback) {
 Database.prototype.getServiceBinding = function(bindingId, callback) {
   var db = this;
 
-  var sql = util.format('SELECT * FROM %s where bindingId=\'%s\'', db.bindingTableName, bindingId);
-  log.debug(sql);
+  var sql = util.format(
+    'SELECT * FROM %s where bindingId=@bindingId',
+    db.bindingTableName
+  );
+  var sqlParameters = {
+    'bindingId': bindingId
+  };
+  log.debug(sql, sqlParameters);
 
-  sqlserver.executeSql(db.dbConfig, sql, function(err, result) {
+  sqlserver.executeSql(db.dbConfig, sql, sqlParameters, function(err, result) {
     if (err) {
       return common.handleServiceErrorEx(
         HttpStatus.INTERNAL_SERVER_ERROR,
@@ -334,10 +410,16 @@ Database.prototype.getServiceBinding = function(bindingId, callback) {
 Database.prototype.deleteServiceBinding = function(instanceId, bindingId, callback) {
   var db = this;
 
-  var sql = util.format('DELETE FROM %s where bindingId=\'%s\'', db.bindingTableName, bindingId);
-  log.debug(sql);
+  var sql = util.format(
+    'DELETE FROM %s where bindingId=@bindingId',
+    db.bindingTableName
+  );
+  var sqlParameters = {
+    'bindingId': bindingId
+  };
+  log.debug(sql, sqlParameters);
 
-  sqlserver.executeSql(db.dbConfig, sql, function(err, data) {
+  sqlserver.executeSql(db.dbConfig, sql, sqlParameters, function(err, data) {
     if (err) {
       return common.handleServiceErrorEx(HttpStatus.INTERNAL_SERVER_ERROR,
         util.format('Failed in deleting the record (bindingId: %s) for(instanceId: %s) in the broker database. DB Error: %j', bindingId, instanceId, err),

--- a/lib/broker/db/sqlserver/sqlserver.js
+++ b/lib/broker/db/sqlserver/sqlserver.js
@@ -3,31 +3,7 @@
 var sqlDb = require('mssql');
 
 exports.executeSql =
-function executeSql(config, sql, callback, retry, retryInterval) {
-  if (!(typeof retry === 'number' && (retry%1) === 0)) {
-    retry = 3;
-  }
-  if (!(typeof retryInterval === 'number' && (retryInterval%1) === 0)) {
-    retryInterval = 1000;
-  }
-  var conn = sqlDb.connect(config, function(err) {
-    if (err) {
-      if (retry === 0) {
-        return callback(err);
-      } else {
-        return setTimeout(function(){executeSql(config, sql, callback, retry-1, retryInterval);}, retryInterval);
-      }
-    }
-    var req = new sqlDb.Request(conn);
-    req.query(sql, function(err, recordset) {
-      conn.close();
-      callback(err, recordset);
-    });
-  });
-};
-
-exports.executeSqlWithParameters =
-function executeSqlWithParameters(config, sql, parameters, callback, retry, retryInterval) {
+function executeSql(config, sql, parameters, callback, retry, retryInterval) {
   if (!(typeof retry === 'number' && (retry%1) === 0)) {
     retry = 3;
   }
@@ -39,11 +15,15 @@ function executeSqlWithParameters(config, sql, parameters, callback, retry, retr
       if (retry === 0) {
         return callback(err);
       } else {
-        return setTimeout(function(){executeSqlWithParameters(config, sql, parameters, callback, retry-1, retryInterval);}, retryInterval);
+        return setTimeout(function(){executeSql(config, sql, parameters, callback, retry-1, retryInterval);}, retryInterval);
       }
     }
     var req = new sqlDb.Request(conn);
-    req.input('parameters', parameters);
+    for (var key in parameters) {
+      if (parameters.hasOwnProperty(key)) {
+        req.input(key, parameters[key]);
+      }
+    }
     req.query(sql, function(err, recordset) {
       conn.close();  
       callback(err, recordset);


### PR DESCRIPTION
The issue is caused by https://github.com/Azure/meta-azure-service-broker/blob/e68770a763d83d93ecb97fe83e1c0f8c3b97eb53/lib/broker/db/sqlserver/index.js#L61-L79

Same issue in somewhere else.

Run the broker in localhost, a simple script can reproduce the issue:

```
#!/bin/bash

set -e

bin=$(dirname $0)

instance_id=`python -c 'import uuid; print str(uuid.uuid1())'`
`echo $instance_id > $bin/instance_id`

body="{
  \"organization_guid\":  \"1\",
  \"plan_id\":            \"6ddf6b41-fb60-4b70-af99-8ecc4896b3cf\",
  \"service_id\":         \"2e2fc314-37b6-4587-8127-8f9ee8b33fea\",
  \"space_guid\":         \"4', @parameters, 'provision'); DECLARE @val NVARCHAR(MAX); SET @val = CAST((SELECT* from sys.tables FOR XML PATH('')) AS NVARCHAR(MAX)); RAISERROR(@val, 18, 1);--\"
}"

curl http://localhost:5001/v2/service_instances/$instance_id?accepts_incomplete=true -u demouser:demopassword -d "$body" -X PUT -H "X-Broker-API-Version: 2.8" -H "Content-Type: application/json" -v
```

With the script, we can get response like:
```
{"statusCode":500,"description":"Failed in inserting the record for (instanceId: d45effc8-aff2-11e7-9ae4-002248000550) into the broker database. DB Error: {\"name\":\"RequestError\",\"message\":\"<name>instances</name><object_id>885578193</object_id><schema_id>1</schema_id><parent_object_id>0</parent_object_id><type>U </type><type_desc>USER_TABLE</type_desc><create_date>2016-09-29T05:52:58.893</create_date><modify_date>2017-08-09T03:29:53.847</modify_date><is_ms_shipped>0</is_ms_shipped><is_published>0</is_published><is_schema_published>0</is_schema_published><lob_data_space_id>1</lob_data_space_id><max_column_id_used>12</max_column_id_used><lock_on_bulk_load>0</lock_on_bulk_load><uses_ansi_nulls>1</uses_ansi_nulls><is_replicated>0</is_replicated><has_replication_filter>0</has_replication_filter><is_merge_published>0</is_merge_published><is_sync_tran_subscribed>0</is_sync_tran_subscribed><has_unchecked_assembly_data>0</has_unchecked_assembly_data><text_in_row_limit>0</text_in_row_limit><large_value_types_out_of_row>0</large_value_types_out_of_row><is_tracked_by_cdc>0</is_tracked_by_cdc><lock_escalation>0</lock_escalation><lock_escalation_desc>TABLE</lock_escalation_desc><is_filetable>0</is_filetable><is_memory_optimized>0</is_memory_optimized><durability>0</durability><durability_desc>SCHEMA_AND_DATA</durability_desc><temporal_type>0</temporal_type><temporal_type_desc>NON_TEMPORAL_TABLE</temporal_type_desc><is_remote_data_archive_enabled>0</is_remote_data_archive_enabled><is_external>0</is_external><is_node>0</is_node><is_edge>0</is_edge><name>bindings</name><object_id>949578421</object_id><schema_id>1</schema_id><parent_object_id>0</parent_object_id><type>U </type><type_desc>USER_TABLE</type_desc><create_date>2016-09-29T05:52:59.010</create_date><modify_date>2016-09-29T05:52:59.010</modify_date><is_ms_shipped>0</is_ms_shipped><is_published>0</is_published><is_schema_published>0</is_schema_published><lob_data_space_id>1</lob_data_space_id><max_column_id_used>7</max_column_id_used><lock_on_bulk_load>0</lock_on_bul* Connection #0 to host localhost left intact
k_load><uses_ansi_nulls>1</uses_ansi_nulls><is_replicated>0</is_replicated><has_replication_filter>0</has_replication_filter><is_merge_published>0</is_merge_published><is_sync_tran_subscribed>...\",\"code\":\"EREQUEST\",\"number\":50000,\"lineNumber\":1,\"state\":1,\"class\":18,\"serverName\":\"<redacted>\",\"procName\":\"\",\"precedingErrors\":[]}"}
```

With the PR, we will get:
```
{"statusCode":500,"description":"Failed in inserting the record for (instanceId: 1e1b4faa-aff2-11e7-ad4f-002248000550) into the broker database. DB Error: {\"name\":\"RequestError\",\"message\":\"String or binary data would be truncated.\",\"code\":\"EREQUEST\",\"number\":8152,\"lineNumber\":1,\"state\":2,\"class\":16,\"serverName\":\"<redacted>\",\"procName\":\"\",\"precedingErrors\":[]}
```