### PR TITLE
Fix JDBC URLs

### DIFF
--- a/lib/services/azuremysqldb/index.js
+++ b/lib/services/azuremysqldb/index.js
@@ -126,10 +126,15 @@ Handlers.bind = function (params, next) {
   var fqdn = provisioningResult.fullyQualifiedDomainName;
   // server login is user@server
   var serverLogin = administratorLogin+'@'+mysqlServerName;
+  // encode the URI components that can contain reserved "delimiter" characters
+  // see: https://tools.ietf.org/html/rfc3986#section-2.2      
+  var encodedUser = encodeURIComponent(serverLogin);
+  var encodedPassword = encodeURIComponent(administratorLoginPassword);
+  
   // Spring Cloud Connector Support
   var jdbcUrlTemplate = 'jdbc:mysql://%s:3306' + 
                         '/%s' + 
-                        '?user=%s@%s' +
+                        '?user=%s' +
                         '&password=%s' +
                         '&verifyServerCertificate=true' +
                         '&useSSL=true' +
@@ -138,15 +143,12 @@ Handlers.bind = function (params, next) {
   var jdbcUrl = util.format(jdbcUrlTemplate,
                             fqdn,
                             mysqlDatabaseName,
-                            administratorLogin, mysqlServerName,
-                            administratorLoginPassword);
-  // encode the URI components that can contain reserved "delimiter" characters
-  // see: https://tools.ietf.org/html/rfc3986#section-2.2      
-  var uriUser = encodeURIComponent(serverLogin);
-  var uriPassword =  encodeURIComponent(administratorLoginPassword);
+                            encodedUser,
+                            encodedPassword);
+  
   var uri = util.format('mysql://%s:%s@%s:3306/%s',
-      uriUser,
-      uriPassword,
+      encodedUser,
+      encodedPassword,
       fqdn,
       mysqlDatabaseName);
   // contents of reply.value winds up in VCAP_SERVICES

--- a/lib/services/azurepostgresqldb/index.js
+++ b/lib/services/azurepostgresqldb/index.js
@@ -126,25 +126,26 @@ Handlers.bind = function (params, next) {
   var fqdn = provisioningResult.fullyQualifiedDomainName;
   // server login is user@server
   var serverLogin = administratorLogin+'@'+postgresqlServerName;
+  // encode the URI components that can contain reserved "delimiter" characters
+  // see: https://tools.ietf.org/html/rfc3986#section-2.2      
+  var encodedUser = encodeURIComponent(serverLogin);
+  var encodedPassword = encodeURIComponent(administratorLoginPassword);
+  
   // Spring Cloud Connector Support
   var jdbcUrlTemplate = 'jdbc:postgresql://%s:5432' + 
                         '/%s' +
-                        '?user=%s@%s' +
+                        '?user=%s' +
                         '&password=%s' +
                         '&ssl=true';
   var jdbcUrl = util.format(jdbcUrlTemplate,
                             fqdn,
                             postgresqlDatabaseName,
-                            administratorLogin,
-                            postgresqlServerName,
-                            encodeURIComponent(administratorLoginPassword));
-  // encode the URI components that can contain reserved "delimiter" characters
-  // see: https://tools.ietf.org/html/rfc3986#section-2.2      
-  var uriUser = encodeURIComponent(serverLogin);
-  var uriPassword =  encodeURIComponent(administratorLoginPassword);
+                            encodedUser,
+                            encodedPassword);
+
   var uri = util.format('postgres://%s:%s@%s:5432/%s',
-      uriUser,
-      uriPassword,
+      encodedUser,
+      encodedPassword,
       fqdn,
       postgresqlDatabaseName);
   // contents of reply.value winds up in VCAP_SERVICES

--- a/lib/services/azuresqldb/index.js
+++ b/lib/services/azuresqldb/index.js
@@ -158,8 +158,12 @@ Handlers.bind = function (params, next) {
       var sqlServerName = provisioningResult.sqlServerName;
       var databaseLogin = result.databaseLogin;
       var databaseLoginPassword = result.databaseLoginPassword;
-            
+      // encode the URI components that can contain reserved "delimiter" characters
+      // see: https://tools.ietf.org/html/rfc3986#section-2.2      
+      var encodedLogin = encodeURIComponent(databaseLogin);
+      var encodedLoginPassword = encodeURIComponent(databaseLoginPassword);
       var fqdn = provisioningResult.fullyQualifiedDomainName;
+
       // Spring Cloud Connector Support
       var jdbcUrlTemplate = 'jdbc:sqlserver://%s:1433;' +
                             'database=%s;' +
@@ -173,21 +177,21 @@ Handlers.bind = function (params, next) {
       var jdbcUrl = util.format(jdbcUrlTemplate,
                                 fqdn,
                                 sqldbName,
-                                databaseLogin,
-                                databaseLoginPassword,
+                                encodedLogin,
+                                encodedLoginPassword,
                                 fqdn.replace(/.+\.database/, '*.database'));
 
       // Differences between auditing enabled and disabled: https://docs.microsoft.com/en-us/azure/sql-database/sql-database-auditing-and-dynamic-data-masking-downlevel-clients
       var jdbcUrlForAuditingEnabled = util.format(jdbcUrlTemplate,
                                                   fqdn.replace(/\.database/, '.database.secure'),
                                                   sqldbName,
-                                                  databaseLogin,
-                                                  encodeURIComponent(databaseLoginPassword),
+                                                  encodedLogin,
+                                                  encodedLoginPassword,
                                                   fqdn.replace(/.+\.database/, '*.database.secure'));
 
       var uri = util.format('mssql://%s:%s@%s:1433/%s?encrypt=true&TrustServerCertificate=false&HostNameInCertificate=%s',
-                            databaseLogin,
-                            databaseLoginPassword,
+                            encodedLogin,
+                            encodedLoginPassword,
                             fqdn,
                             sqldbName,
                             fqdn.replace(/.+\.database/, '%2A.database'));


### PR DESCRIPTION
Tested by using Spring Connectors, the JDBC URLs can't be parsed by the parser, with the change of password generator in https://github.com/Azure/meta-azure-service-broker/pull/155.
Impacted modules: sqldb/mysqldb/postgresqldb.