### PR TITLE
Correct migration version number

### DIFF
--- a/docs/migration/lower_1.4.0_to_1.4.0_or_greater.js
+++ b/docs/migration/lower_1.4.0_to_1.4.0_or_greater.js
@@ -1,5 +1,5 @@
 /* 
- * This is a script for migrating Azure Service Broker from 1.2.1 to 1.3.0 or greater.
+ * This is a script for migrating Azure Service Broker from lower than 1.4.0 to 1.4.0 or greater.
  * Usage: "node migration.js <path-to-manifest.yml>"
  * NOTE: The version of node module 'mssql' is 3.1.2.
  *       The version of node module 'js-yaml' is 3.1.0.

--- a/docs/migration/lower_1.4.0_to_1.4.0_or_greater.md
+++ b/docs/migration/lower_1.4.0_to_1.4.0_or_greater.md
@@ -1,4 +1,4 @@
-# Migrate from v1.2.1 to v1.3.0 or greater
+# Migrate from <1.4.0 to >=1.4.0
 
 This is a guidance to fix https://github.com/Azure/meta-azure-service-broker/issues/154.
 
@@ -19,7 +19,7 @@ This is a guidance to fix https://github.com/Azure/meta-azure-service-broker/iss
 Run
 
 ```
-node 1.2.1_to_1.3.0_or_greater.js manifest.yml
+node lower_1.4.0_to_1.4.0_or_greater.js manifest.yml
 ```
 
 **NOTE**: It is just your manifest.yml with filled `AZURE_BROKER_DATABASE_SERVER`, `AZURE_BROKER_DATABASE_USER`, `AZURE_BROKER_DATABASE_PASSWORD`, `AZURE_BROKER_DATABASE_NAME`, and `AZURE_BROKER_DATABASE_ENCRYPTION_KEY`. Filling them in a blank [manifest.yml](https://github.com/Azure/meta-azure-service-broker/blob/master/manifest.yml) to use is OK, too.


### PR DESCRIPTION
https://github.com/Azure/meta-azure-service-broker/releases/tag/v1.4.0
The release note shows that the breaking change mentioned in https://github.com/Azure/meta-azure-service-broker/issues/154 was done in v1.4.0.

This PR corrects the migration version number.
Ensure that further migrations from MASB in any version to ASB follow the right steps.