### PR TITLE
not encode username and password in sqldb JDBC URL

### DIFF
--- a/lib/services/azuresqldb/index.js
+++ b/lib/services/azuresqldb/index.js
@@ -177,16 +177,16 @@ Handlers.bind = function (params, next) {
       var jdbcUrl = util.format(jdbcUrlTemplate,
                                 fqdn,
                                 sqldbName,
-                                encodedLogin,
-                                encodedLoginPassword,
+                                databaseLogin,
+                                databaseLoginPassword,
                                 fqdn.replace(/.+\.database/, '*.database'));
 
       // Differences between auditing enabled and disabled: https://docs.microsoft.com/en-us/azure/sql-database/sql-database-auditing-and-dynamic-data-masking-downlevel-clients
       var jdbcUrlForAuditingEnabled = util.format(jdbcUrlTemplate,
                                                   fqdn.replace(/\.database/, '.database.secure'),
                                                   sqldbName,
-                                                  encodedLogin,
-                                                  encodedLoginPassword,
+                                                  databaseLogin,
+                                                  databaseLoginPassword,
                                                   fqdn.replace(/.+\.database/, '*.database.secure'));
 
       var uri = util.format('mssql://%s:%s@%s:1433/%s?encrypt=true&TrustServerCertificate=false&HostNameInCertificate=%s',


### PR DESCRIPTION
Revert the sqldb part in https://github.com/Azure/meta-azure-service-broker/pull/160.
Different from PostgreSQL and MySQL driver, I don't know why SQL Server JDBC driver can't parse encoded JDBC URL.
Anyway this PR should be the final fix for this topic.