### PR TITLE
Add a service plan to azure-sqldb service to support registering existing database as service instance

### DIFF
--- a/examples/sqldb-example-registered-database-config.json
+++ b/examples/sqldb-example-registered-database-config.json
@@ -1,0 +1,6 @@
+{
+    "sqlServerName": "<name-of-server-provided-in-manifest>",
+    "sqldbName": "<name-of-existing-database>",
+    "userProvidedDatabaseLogin": "<name-of-existing-database-login>",
+    "userProvidedDatabaseLoginPassword": "<password-of-existing-database-login>"
+}

--- a/lib/services/azuresqldb/cmd-bind.js
+++ b/lib/services/azuresqldb/cmd-bind.js
@@ -18,16 +18,19 @@ var sqldbBind = function (params) {
     log.info(util.format('sqldb cmd-bind: resourceGroupName: %s, sqldbName: %s, sqlServerName: %s', resourceGroupName, sqldbName, sqlServerName));
 
     this.bind = function (sqldbOperations, next) {
-
+        if (reqParams.userProvidedDatabaseLogin) {
+            return next(null, {
+                databaseLogin: reqParams.userProvidedDatabaseLogin,
+                databaseLoginPassword: reqParams.userProvidedDatabaseLoginPassword
+            });
+        }
         sqldbOperations.setParameters(resourceGroupName, sqlServerName, sqldbName);
-        
         var databaseLogin, databaseLoginPassword;
-        
         async.waterfall([
             function (callback) {
                 databaseLogin = common.generateName();
                 databaseLoginPassword = common.generateStrongPassword();
-                
+
                 // create the login
                 sqldbOperations.createDatabaseLogin(
                     provisioningResult.fullyQualifiedDomainName,

--- a/lib/services/azuresqldb/cmd-bind.js
+++ b/lib/services/azuresqldb/cmd-bind.js
@@ -19,6 +19,7 @@ var sqldbBind = function (params) {
 
     this.bind = function (sqldbOperations, next) {
         if (reqParams.userProvidedDatabaseLogin) {
+            // assume the login/password provided by user always work
             return next(null, {
                 databaseLogin: reqParams.userProvidedDatabaseLogin,
                 databaseLoginPassword: reqParams.userProvidedDatabaseLoginPassword

--- a/lib/services/azuresqldb/cmd-deprovision.js
+++ b/lib/services/azuresqldb/cmd-deprovision.js
@@ -10,7 +10,7 @@ var sqldbDeprovision = function (params) {
 
     var provisioningResult = params.provisioning_result;
     var resourceGroupName = provisioningResult.resourceGroup;
-    var sqldbName = provisioningResult.name;    
+    var sqldbName = provisioningResult.name;
     var sqlServerName = provisioningResult.sqlServerName;
 
     log.info(util.format('sqldb cmd-deprovision: resourceGroupName: %s, sqldbName: %s, sqlServerName: %s', resourceGroupName, sqldbName, sqlServerName));
@@ -18,18 +18,24 @@ var sqldbDeprovision = function (params) {
     this.deprovision = function (sqldbOperations, next) {
 
         sqldbOperations.setParameters(resourceGroupName, sqlServerName, sqldbName);
-
-        sqldbOperations.deleteDatabase(function (err) {
-            if (err) {
-                log.error('sqldb cmd-deprovision: async.waterfall/deleteDatabase: err: %j', err);
-                return next(err);
-            } else {
-                var result = {};
-                result.state = 'succeeded';
-                result.description = 'Deleted database';
-                next(null, result);
-            }
-        });
+        if (params.plan_id === '4b1cfc28-dda6-407b-abeb-7aa0b89f52bf') {
+            var result = {};
+            result.state = 'succeeded';
+            result.description = 'Unregistered the database';
+            next(null, result);
+        } else {
+          sqldbOperations.deleteDatabase(function (err) {
+              if (err) {
+                  log.error('sqldb cmd-deprovision: async.waterfall/deleteDatabase: err: %j', err);
+                  return next(err);
+              } else {
+                  var result = {};
+                  result.state = 'succeeded';
+                  result.description = 'Deleted database';
+                  next(null, result);
+              }
+          });
+        }
     };
 };
 

--- a/lib/services/azuresqldb/cmd-poll.js
+++ b/lib/services/azuresqldb/cmd-poll.js
@@ -27,12 +27,16 @@ var sqldbPoll = function (params) {
 
         sqldbOperations.setParameters(resourceGroupName, sqlServerName, sqldbName);
         if (params.plan_id === '4b1cfc28-dda6-407b-abeb-7aa0b89f52bf') {
+            // we only need handle (lastoperation === 'provision' || lastoperation === 'deprovision') for the plan as update is prevented.
             var result = {};
             result.body = provisioningResult;
             result.value = {
                 state: 'succeeded',
                 description: 'Registered the database as a service instance.'
             };
+            if (lastoperation === 'deprovision') {
+                result.value.description = 'Unregistered the database.';
+            }
             return next(null, result);
         } else if (lastoperation === 'update'){
             // Use the operationResult endpoint to poll long async requests like Update

--- a/lib/services/azuresqldb/cmd-poll.js
+++ b/lib/services/azuresqldb/cmd-poll.js
@@ -13,21 +13,28 @@ var log = common.getLogger(Config.name);
 var sqldbPoll = function (params) {
 
     var reqParams = params.parameters || {};
-    var provisioningResult = params.provisioning_result || {};    
+    var provisioningResult = params.provisioning_result || {};
     var lastoperation = params.last_operation || '';
     var resourceGroupName = provisioningResult.resourceGroup || '';
     var sqldbName = reqParams.sqldbName || '';
     var sqlServerName = reqParams.sqlServerName || '';
     var tde = reqParams.transparentDataEncryption;
     if (tde === undefined) tde = params.defaultSettings.sqldb.transparentDataEncryption;
-    
+
     log.info(util.format('sqldb cmd-poll: resourceGroupName: %s, sqldbName: %s, sqlServerName: %s', resourceGroupName, sqldbName, sqlServerName));
 
     this.poll = function (sqldbOperations, next) {
 
         sqldbOperations.setParameters(resourceGroupName, sqlServerName, sqldbName);
-
-        if (lastoperation === 'update'){
+        if (params.plan_id === '4b1cfc28-dda6-407b-abeb-7aa0b89f52bf') {
+            var result = {};
+            result.body = provisioningResult;
+            result.value = {
+                state: 'succeeded',
+                description: 'Registered the database as a service instance.'
+            };
+            return next(null, result);
+        } else if (lastoperation === 'update'){
             // Use the operationResult endpoint to poll long async requests like Update
             async.waterfall([
                 function (callback){
@@ -63,9 +70,7 @@ var sqldbPoll = function (params) {
                 result.value = reply;
                 return next(err, result);
             });
-        }
-        else {
-
+        } else {
             async.waterfall([
                 function (callback) {
                     // get status of database
@@ -84,12 +89,12 @@ var sqldbPoll = function (params) {
                             if (lastoperation === 'provision') {
                                 if (result.statusCode === HttpStatus.OK) {
                                     result.body = _.extend(result.body, provisioningResult);
-                                                            
+
                                     reply.state = 'succeeded';
                                     reply.description = 'Created logical database ' + reqParams.sqldbName + ' on logical server ' + reqParams.sqlServerName + '.';
-                                } else if (result.statusCode === HttpStatus.NOT_FOUND) { 
+                                } else if (result.statusCode === HttpStatus.NOT_FOUND) {
                                     result.body = provisioningResult;
-                                            
+
                                     reply.state = 'in progress';
                                     reply.description = 'Creating logical database ' + reqParams.sqldbName + ' on logical server ' + reqParams.sqlServerName + '.';
                                 }
@@ -107,7 +112,7 @@ var sqldbPoll = function (params) {
                         }
                     });
                 },
-                function(result, callback) {   // Set Transparent data encryption  
+                function(result, callback) {   // Set Transparent data encryption
                     if ( lastoperation === 'provision' && result.value.state === 'succeeded' && tde === true){
                         log.info('sqldb cmd-poll: async.waterfall/Set transparent data encryption: Enabled');
                         sqldbOperations.setTransparentDataEncryption(function (err, tdeResult) {
@@ -135,4 +140,3 @@ var sqldbPoll = function (params) {
 };
 
 module.exports = sqldbPoll;
-

--- a/lib/services/azuresqldb/cmd-provision.js
+++ b/lib/services/azuresqldb/cmd-provision.js
@@ -95,30 +95,20 @@ var sqldbProvision = function (params) {
                 if (err) {
                     log.error('sqldb cmd-provision: get the sql server: err: %j', err);
                     return callback(err);
-                } else {
-                    log.info('sqldb cmd-provision: get the sql server: %j', result);
-                    callback(null, result);
                 }
+                log.debug('sqldb cmd-provision: getting sql server result: %j', result);
+                callback(null, result);
             });
         }
 
         function getDatabase(callback) {
-            log.info('sqldb cmd-provision: check existence of database');
             sqldbOperations.getDatabase(function (err, result) {
                if (err) {
                    log.error('sqldb cmd-provision: check existence of sql database: err: %j', err);
-                   callback(err);
-               } else if (result.statusCode === HttpStatus.NOT_FOUND) {
-                   callback(null);
-               } else if (result.statusCode === HttpStatus.OK) {
-                   var error = Error('The database name is not available.');
-                   error.statusCode = HttpStatus.CONFLICT;
-                   callback(error);
-               } else {
-                   var errorMsg = util.format('sqldb cmd-provision: check existence of sql database, unexpected error: result: %j', result);
-                   log.error(errorMsg);
-                   callback(Error(errorMsg));
+                   return callback(err);
                }
+               log.debug('sqldb cmd-provision: getting sql database result: %j', result);
+               callback(null, result);
            });
         }
 
@@ -145,18 +135,67 @@ var sqldbProvision = function (params) {
         }
 
         sqldbOperations.setParameters(resourceGroupName, sqlServerName, sqldbName, location);
+        if (params.plan_id === '4b1cfc28-dda6-407b-abeb-7aa0b89f52bf') {
+          async.waterfall([
+              function (callback) {  // get sql server status (existence check)
+                  getServer(callback);
+              },
+              function (result, callback) {
+                  if (result.statusCode === HttpStatus.NOT_FOUND) {
+                      var errorMessage = 'The specified server does not exist.';
+                      callback(Error(errorMessage));
+                  } else if (result.statusCode === HttpStatus.OK) {  // sql server exists
+                      log.info('sqldb cmd-provision: found the sql server.');
+                      fullyQualifiedDomainName = JSON.parse(result.body).properties.fullyQualifiedDomainName;
+                      callback(null);
+                  } else {
+                      var errorMessage = util.format('Unexpected error: %j', result);
+                      callback(Error(errorMessage));
+                  }
+              },
+              function (callback) {  // get sql database status (existence check)
+                  getDatabase(callback);
+              },
+              function (result, callback) {
+                  if (result.statusCode === HttpStatus.NOT_FOUND) {
+                      var errorMessage = 'The specified database does not exist on the server.';
+                      callback(Error(errorMessage));
+                  } else if (result.statusCode === HttpStatus.OK) {  // sql server exists
+                      log.info('sqldb cmd-provision: found the sql database.');
+                      result.body.resourceGroup = resourceGroupName;
+                      result.body.sqlServerName = sqlServerName;
+                      result.body.fullyQualifiedDomainName = fullyQualifiedDomainName;
+                      result.body.administratorLogin = administratorLogin;
+                      result.body.administratorLoginPassword = administratorLoginPassword;
 
-        if (!privilege.allowToCreateSqlServer) {
+                      result.value = {};
+                      result.value.state = 'in progress';
+                      result.value.description = 'Found the database ' + reqParams.sqldbName + ' on server ' + reqParams.sqlServerName + '.';
+                      callback(null, result);
+                  } else {
+                      var errorMessage = util.format('Unexpected error: %j', result);
+                      callback(Error(errorMessage));
+                  }
+              }
+          ], function (err, result) {
+              if (err) {
+                  log.error('sqldb cmd-provision: final callback: err: ', err);
+              } else {
+                  log.info('sqldb cmd-provision: final callback: result: %j', result.value);
+              }
+              next(err, result);
+          });
+        } else if (!privilege.allowToCreateSqlServer) {
             async.waterfall([
                 function (callback) {  // get sql server status (existence check)
                     getServer(callback);
                 },
                 function (result, callback) {
                     if (result.statusCode === HttpStatus.NOT_FOUND) {
-                        var errorMessage = util.format('The specified server does not exist but you do not have the privilege to create a new server.');
+                        var errorMessage = 'The specified server does not exist but you do not have the privilege to create a new server.';
                         callback(Error(errorMessage));
                     } else if (firewallRules !== null) {
-                        var errorMessage = util.format('You specify the firewall rules for the server but you do not have the privilege to operate the server.');
+                        var errorMessage = 'You specify the firewall rules for the server but you do not have the privilege to operate the server.';
                         callback(Error(errorMessage));
                     } else if (result.statusCode === HttpStatus.OK) {
                         fullyQualifiedDomainName = JSON.parse(result.body).properties.fullyQualifiedDomainName;
@@ -168,6 +207,19 @@ var sqldbProvision = function (params) {
                 },
                 function (callback) {   // see if db exists (in the case that sql server was there already)
                     getDatabase(callback);
+                },
+                function (result, callback) {
+                    if (result.statusCode === HttpStatus.NOT_FOUND) {
+                        callback(null);
+                    } else if (result.statusCode === HttpStatus.OK) {
+                        var error = Error('The database name is not available.');
+                        error.statusCode = HttpStatus.CONFLICT;
+                        callback(error);
+                    } else {
+                        var errorMsg = util.format('sqldb cmd-provision: check existence of sql database, unexpected error: result: %j', result);
+                        log.error(errorMsg);
+                        callback(Error(errorMsg));
+                    }
                 },
                 function (callback) {  // create the database
                     createDatabase(callback);
@@ -212,7 +264,7 @@ var sqldbProvision = function (params) {
                         callback(null);
                     } else {
                         var errorMessage = util.format('Unexpected error: %j', result);
-                        log.error(Error(errorMessage));
+                        log.error(errorMessage);
                         callback(Error(errorMessage));
                     }
                 },
@@ -261,6 +313,19 @@ var sqldbProvision = function (params) {
                 },
                 function (callback) {   // see if db exists (in the case that sql server was there already)
                     getDatabase(callback);
+                },
+                function (result, callback) {
+                    if (result.statusCode === HttpStatus.NOT_FOUND) {
+                        callback(null);
+                    } else if (result.statusCode === HttpStatus.OK) {
+                        var error = Error('The database name is not available.');
+                        error.statusCode = HttpStatus.CONFLICT;
+                        callback(error);
+                    } else {
+                        var errorMsg = util.format('sqldb cmd-provision: check existence of sql database, unexpected error: result: %j', result);
+                        log.error(errorMsg);
+                        callback(Error(errorMsg));
+                    }
                 },
                 function (callback) {  // create the database
                     createDatabase(callback);
@@ -335,6 +400,21 @@ var sqldbProvision = function (params) {
         return true;
     };
 
+    this.checkUserProvidedDatabaseLogin = function () {
+        var bothOrNeither = ((reqParams.userProvidedDatabaseLogin === undefined) ===
+            (reqParams.userProvidedDatabaseLoginPassword === undefined));
+        if (!bothOrNeither) {
+            return ['userProvidedDatabaseLogin', 'userProvidedDatabaseLoginPassword'];
+        } else if (reqParams.userProvidedDatabaseLogin) {
+            var ret = [];
+            if (!_.isString(reqParams.userProvidedDatabaseLogin)) ret.push('userProvidedDatabaseLogin');
+            if (!_.isString(reqParams.userProvidedDatabaseLoginPassword)) ret.push('userProvidedDatabaseLoginPassword');
+            return ret;
+        } else {
+            return [];
+        }
+    };
+
     this.getInvalidParams = function () {
         var invalidParams = [];
         invalidParams = invalidParams.concat(this.parametersNotProvided());
@@ -342,9 +422,9 @@ var sqldbProvision = function (params) {
         if (!this.sqlDbCollationWasProvided()) invalidParams.push('collation');
         if (!this.firewallRuleIsOk()) invalidParams.push('allowSqlServerFirewallRules');
         if (!this.noDeprecatedParametersWereProvided()) invalidParams.push('sqlServerCreateIfNotExist');
+        invalidParams = invalidParams.concat(this.checkUserProvidedDatabaseLogin());
         return invalidParams;
     };
 };
 
 module.exports = sqldbProvision;
-

--- a/lib/services/azuresqldb/cmd-provision.js
+++ b/lib/services/azuresqldb/cmd-provision.js
@@ -56,7 +56,6 @@ var sqldbProvision = function (params) {
     // this is to minimize the amount of static data
     // that must be included in the developer's parameters file
     this.fixupParameters = function () {
-
         // patch up the sqlServerParameters
         if (_.isUndefined(params.parameters.sqlServerParameters)) {
             params.parameters.sqlServerParameters = {};
@@ -66,6 +65,12 @@ var sqldbProvision = function (params) {
         }
         params.parameters.sqlServerParameters.properties.version = '12.0';
 
+        if (_.isUndefined(params.parameters.sqldbParameters)) {
+            params.parameters.sqldbParameters = {};
+        }
+        if (_.isUndefined(params.parameters.sqldbParameters.properties)) {
+            params.parameters.sqldbParameters.properties = {};
+        }
         // figure out what plan they selected and fill in some properties
         var planId = params.plan_id;
         log.info('SqlDb/cmd-provision/fixup parameters/planid: %j', planId);
@@ -136,55 +141,55 @@ var sqldbProvision = function (params) {
 
         sqldbOperations.setParameters(resourceGroupName, sqlServerName, sqldbName, location);
         if (params.plan_id === '4b1cfc28-dda6-407b-abeb-7aa0b89f52bf') {
-          async.waterfall([
-              function (callback) {  // get sql server status (existence check)
-                  getServer(callback);
-              },
-              function (result, callback) {
-                  if (result.statusCode === HttpStatus.NOT_FOUND) {
-                      var errorMessage = 'The specified server does not exist.';
-                      callback(Error(errorMessage));
-                  } else if (result.statusCode === HttpStatus.OK) {  // sql server exists
-                      log.info('sqldb cmd-provision: found the sql server.');
-                      fullyQualifiedDomainName = JSON.parse(result.body).properties.fullyQualifiedDomainName;
-                      callback(null);
-                  } else {
-                      var errorMessage = util.format('Unexpected error: %j', result);
-                      callback(Error(errorMessage));
-                  }
-              },
-              function (callback) {  // get sql database status (existence check)
-                  getDatabase(callback);
-              },
-              function (result, callback) {
-                  if (result.statusCode === HttpStatus.NOT_FOUND) {
-                      var errorMessage = 'The specified database does not exist on the server.';
-                      callback(Error(errorMessage));
-                  } else if (result.statusCode === HttpStatus.OK) {  // sql server exists
-                      log.info('sqldb cmd-provision: found the sql database.');
-                      result.body.resourceGroup = resourceGroupName;
-                      result.body.sqlServerName = sqlServerName;
-                      result.body.fullyQualifiedDomainName = fullyQualifiedDomainName;
-                      result.body.administratorLogin = administratorLogin;
-                      result.body.administratorLoginPassword = administratorLoginPassword;
+            async.waterfall([
+                function (callback) {  // get sql server status (existence check)
+                    getServer(callback);
+                },
+                function (result, callback) {
+                    if (result.statusCode === HttpStatus.NOT_FOUND) {
+                        var errorMessage = 'The specified server does not exist.';
+                        callback(Error(errorMessage));
+                    } else if (result.statusCode === HttpStatus.OK) {  // sql server exists
+                        log.info('sqldb cmd-provision: found the sql server.');
+                        fullyQualifiedDomainName = JSON.parse(result.body).properties.fullyQualifiedDomainName;
+                        callback(null);
+                    } else {
+                        var errorMessage = util.format('Unexpected error: %j', result);
+                        callback(Error(errorMessage));
+                    }
+                },
+                function (callback) {  // get sql database status (existence check)
+                    getDatabase(callback);
+                },
+                function (result, callback) {
+                    if (result.statusCode === HttpStatus.NOT_FOUND) {
+                        var errorMessage = 'The specified database does not exist on the server.';
+                        callback(Error(errorMessage));
+                    } else if (result.statusCode === HttpStatus.OK) {  // sql database exists
+                        log.info('sqldb cmd-provision: found the sql database.');
+                        result.body.resourceGroup = resourceGroupName;
+                        result.body.sqlServerName = sqlServerName;
+                        result.body.fullyQualifiedDomainName = fullyQualifiedDomainName;
+                        result.body.administratorLogin = administratorLogin;
+                        result.body.administratorLoginPassword = administratorLoginPassword;
 
-                      result.value = {};
-                      result.value.state = 'in progress';
-                      result.value.description = 'Found the database ' + reqParams.sqldbName + ' on server ' + reqParams.sqlServerName + '.';
-                      callback(null, result);
-                  } else {
-                      var errorMessage = util.format('Unexpected error: %j', result);
-                      callback(Error(errorMessage));
-                  }
-              }
-          ], function (err, result) {
-              if (err) {
-                  log.error('sqldb cmd-provision: final callback: err: ', err);
-              } else {
-                  log.info('sqldb cmd-provision: final callback: result: %j', result.value);
-              }
-              next(err, result);
-          });
+                        result.value = {};
+                        result.value.state = 'in progress';
+                        result.value.description = 'Found the database ' + reqParams.sqldbName + ' on server ' + reqParams.sqlServerName + '.';
+                        callback(null, result);
+                    } else {
+                        var errorMessage = util.format('Unexpected error: %j', result);
+                        callback(Error(errorMessage));
+                    }
+                }
+            ], function (err, result) {
+                if (err) {
+                    log.error('sqldb cmd-provision: final callback: err: ', err);
+                } else {
+                    log.info('sqldb cmd-provision: final callback: result: %j', result.value);
+                }
+                next(err, result);
+            });
         } else if (!privilege.allowToCreateSqlServer) {
             async.waterfall([
                 function (callback) {  // get sql server status (existence check)

--- a/lib/services/azuresqldb/cmd-unbind.js
+++ b/lib/services/azuresqldb/cmd-unbind.js
@@ -19,8 +19,10 @@ var sqldbUnbind = function (params) {
     log.info(util.format('sqldb cmd-unbind: resourceGroupName: %s, sqldbName: %s, sqlServerName: %s', resourceGroupName, sqldbName, sqlServerName));
 
     this.unbind = function (sqldbOperations, next) {
+        if (reqParams.userProvidedDatabaseLogin) {
+            return next(null);
+        }
         sqldbOperations.setParameters(resourceGroupName, sqlServerName, sqldbName);
-        
         async.waterfall([
             function (callback) {
                 log.info('sqldb cmd-unbind: async.waterfall/dropUserOfDatabaseLogin');
@@ -58,7 +60,7 @@ var sqldbUnbind = function (params) {
             log.info('sqldb cmd-unbind: async.waterfall/final callback: err: ', err);
             next(err);
         });
-                
+
     };
 };
 

--- a/lib/services/azuresqldb/cmd-update.js
+++ b/lib/services/azuresqldb/cmd-update.js
@@ -1,3 +1,5 @@
+/* jshint camelcase: false */
+
 var _ = require('underscore');
 var Config = require('./service');
 var common = require('../../common');
@@ -6,17 +8,21 @@ var HttpStatus = require('http-status-codes');
 var async = require('async');
 
 var sqldbUpdate = function (params) {
-    
+
     // Updates the the service instance to match desired parameters (params) and yields the resulting instance (updatedInstance)
     this.update = function (sqldbOps, next) {
+        if (params.plan_id === '4b1cfc28-dda6-407b-abeb-7aa0b89f52bf') {
+            var errorMessage = 'Registered database should not be updated.';
+            return next(Error(errorMessage));
+        }
         log.info('sqldb cmd-update.update invoked');
         var provisioningResult = params.instance['provisioning_result'];
         sqldbOps.setParameters(provisioningResult.resourceGroup, provisioningResult.sqlServerName, provisioningResult.name);
-        
+
         // The updated instance will be stored in the broker database.
         var updatedInstance = _.extend({}, params.instance);
         updatedInstance['last_operation'] = 'update';
-        
+
         // Update the old password stored in the broker DB when the server password is changed manually outside of Cloud Foundry
         if (params.requested.parameters && params.requested.parameters.sqlServerParameters && params.requested.parameters.sqlServerParameters.properties) {
             var newPassword = params.requested.parameters.sqlServerParameters.properties.administratorLoginPassword;
@@ -31,18 +37,18 @@ var sqldbUpdate = function (params) {
                 } };
             return next(null, reply, updatedInstance);
         }
-        
+
         var planId = params.requested['plan_id'];
-        
+
         if (planId) {
             updatedInstance['plan_id'] = planId;
 
             // Example ID "/subscriptions/f5839dfd-61f0-4b2f-b06f-de7fc47b5998/resourceGroups/user-rg1/provider;s/Microsoft.Sql/servers/user-mysqlsvr/databases/mydb"
             updatedInstance.parameters.sqldbParameters.properties.sourceDatabaseId = provisioningResult.id;
-            
+
             // Update the service plan
             // Get the preset azure parameters for the new plan
-           
+
             Config.plans.forEach(function (item) {
                 if (planId === item.id) {
                     log.info('SqlDb/cmd-provision/fixup parameters/plan name: %j', item.name);
@@ -52,9 +58,9 @@ var sqldbUpdate = function (params) {
                 }
             });
         }
-        
+
         // Parameter format sent to CreateDatabase:
-        // var updateRequest = { 
+        // var updateRequest = {
         //     properties: {
         //         collation: "SQL_Latin1_General_CP1_CI_AS",
         //         maxSizeBytes: "2147483648",
@@ -65,10 +71,10 @@ var sqldbUpdate = function (params) {
         //     tags: { "user-agent": "meta-azure-service-broker" },
         //     location: "West US"
         // }
-        
+
         // Copy location since it is required for the request
         updatedInstance.parameters.location  = params.instance.parameters.location || params.instance['provisioning_result'].location;
-        
+
         async.waterfall([
             function(callback){
                 sqldbOps.createDatabase(updatedInstance.parameters, callback);
@@ -78,15 +84,15 @@ var sqldbUpdate = function (params) {
                 log.error('sqldb cmd-update: create sql database: err: %j, result: %j', err, result);
                 return next(err);
             } else {
-                
+
                 // Save result that is used for polling this async operation
                 if (result.res.headers && result.res.headers['azure-asyncoperation']){
                     var asyncOperation = result.res.headers['azure-asyncoperation'];
                     updatedInstance.state.asyncOperation = asyncOperation;
                 }
-                
+
                 log.info('sqldb cmd-update: create sql database success: result: %j', result);
-                var reply = { 
+                var reply = {
                     statusCode: HttpStatus.ACCEPTED,
                     code: HttpStatus.getStatusText(HttpStatus.ACCEPTED),
                     value: {

--- a/lib/services/azuresqldb/service.json
+++ b/lib/services/azuresqldb/service.json
@@ -577,12 +577,7 @@
           "Registered"
         ],
         "displayName": "Registered",
-        "details": {
-          "createMode": "",
-          "edition": "",
-          "maxSizeBytes": "",
-          "requestedServiceObjectiveName": ""
-        }
+        "details": {}
       }
     }
   ]

--- a/lib/services/azuresqldb/service.json
+++ b/lib/services/azuresqldb/service.json
@@ -566,6 +566,24 @@
           "requestedServiceObjectiveName": "DW1200"
         }
       }
+    },
+    {
+      "id": "4b1cfc28-dda6-407b-abeb-7aa0b89f52bf",
+      "name": "Registered",
+      "free": false,
+      "description": "Register existing database to use. The database won't be deleted in deprovisioning.",
+      "metadata": {
+        "bullets": [
+          "Registered"
+        ],
+        "displayName": "Registered",
+        "details": {
+          "createMode": "",
+          "edition": "",
+          "maxSizeBytes": "",
+          "requestedServiceObjectiveName": ""
+        }
+      }
     }
   ]
 }

--- a/test/unit/services/azuresqldb/bind-spec.js
+++ b/test/unit/services/azuresqldb/bind-spec.js
@@ -1,6 +1,6 @@
 /*
   good instanceId : e2778b98-0b6b-11e6-9db3-000d3a002ed5
-  test: 
+  test:
 */
 
 /* jshint camelcase: false */
@@ -79,6 +79,7 @@ describe('SqlDb - bind', function () {
         };
 
         cb = new cmdbind(validParams);
+        sinon.stub(sqldbOps, 'executeSql').yields(null);
     });
 
     after(function () {
@@ -86,12 +87,71 @@ describe('SqlDb - bind', function () {
     });
 
     describe('', function () {
-        sinon.stub(sqldbOps, 'executeSql').yields(null);
         it('should not callback error', function (done) {
             cb.bind(sqldbOps, function (err, result) {
                 should.not.exist(err);
                 should.exist(result.databaseLogin);
                 should.exist(result.databaseLoginPassword);
+                done();
+            });
+        });
+    });
+});
+
+describe('SqlDb - bind - user-provided database login', function () {
+
+    var cb;
+
+    before(function () {
+
+        var validParams = {
+            instance_id: 'e2778b98-0b6b-11e6-9db3-000d3a002ed5',
+            service_id: 'fb9bc99e-0aa9-11e6-8a8a-000d3a002ed5',
+            plan_id: '3819fdfa-0aaa-11e6-86f4-000d3a002ed5',
+            parameters: {
+                sqlServerName: 'golive4',
+                sqldbName: 'sqldb',
+                userProvidedDatabaseLogin: 'fake-login',
+                userProvidedDatabaseLoginPassword: 'fake-login-password',
+            },
+            provisioning_result: {
+                'id': '/subscriptions/743f6ed6-83a8-46f0-822d-ea93b953952d/resourceGroups/sqldbResourceGroup/providers/Microsoft.Sql/servers/golive4/databases/sqldb',
+                'name': 'sqldb',
+                'type': 'Microsoft.Sql/servers/databases',
+                'location': 'West US',
+                'kind': 'v12.0,user',
+                'properties': {
+                    'databaseId': 'bf19fd8d-8b08-4b11-aceb-16dafee3c7cc',
+                    'edition': 'Basic',
+                    'status': 'Online',
+                    'serviceLevelObjective': 'Basic',
+                    'collation': 'SQL_Latin1_General_CP1_CI_AS',
+                    'maxSizeBytes': '2147483648',
+                    'creationDate': '2016-07-08T08:54:17.73Z',
+                    'currentServiceObjectiveId': 'dd6d99bb-f193-4ec1-86f2-43d3bccbc49c',
+                    'requestedServiceObjectiveId': 'dd6d99bb-f193-4ec1-86f2-43d3bccbc49c',
+                    'requestedServiceObjectiveName': null,
+                    'defaultSecondaryLocation': 'East US',
+                    'earliestRestoreDate': '2016-07-08T09:05:03.543Z',
+                    'elasticPoolName': null,
+                    'containmentState': 2
+                },
+                'sqlServerName': 'golive4',
+                'administratorLogin': 'greg',
+                'administratorLoginPassword': 'P@ssw0rd!'
+            },
+            azure: azure
+        };
+
+        cb = new cmdbind(validParams);
+    });
+
+    describe('', function () {
+        it('should not callback error', function (done) {
+            cb.bind(sqldbOps, function (err, result) {
+                should.not.exist(err);
+                result.databaseLogin.should.equal('fake-login');
+                result.databaseLoginPassword.should.equal('fake-login-password');
                 done();
             });
         });

--- a/test/unit/services/azuresqldb/deprovision-spec.js
+++ b/test/unit/services/azuresqldb/deprovision-spec.js
@@ -1,6 +1,6 @@
 /*
   good instanceId : e2778b98-0b6b-11e6-9db3-000d3a002ed5
-  test: 
+  test:
 */
 
 /* jshint camelcase: false */
@@ -60,7 +60,7 @@ describe('SqlDb - Deprovision', function () {
         };
 
         cd = new cmdDeprovision(validParams);
-        
+
         msRestRequest.DELETE = sinon.stub();
         msRestRequest.DELETE.withArgs('https://management.azure.com//subscriptions/55555555-4444-3333-2222-111111111111/resourceGroups/sqldbResourceGroup/providers/Microsoft.Sql/servers/golive4/databases/sqldb')
           .yields(null, {statusCode: 200});
@@ -76,6 +76,61 @@ describe('SqlDb - Deprovision', function () {
                 should.not.exist(err);
                 result.state.should.equal('succeeded');
                 result.description.should.equal('Deleted database');
+                done();
+            });
+        });
+    });
+});
+
+describe('SqlDb - Deprovision - Registering existing database plan', function () {
+
+    var cd;
+
+    before(function () {
+
+        var validParams = {
+            instance_id: 'e2778b98-0b6b-11e6-9db3-000d3a002ed5',
+            service_id: 'fb9bc99e-0aa9-11e6-8a8a-000d3a002ed5',
+            plan_id: '4b1cfc28-dda6-407b-abeb-7aa0b89f52bf',
+            provisioning_result: {
+                'resourceGroup': 'sqldbResourceGroup',
+                'id': '/subscriptions/743f6ed6-83a8-46f0-822d-ea93b953952d/resourceGroups/sqldbResourceGroup/providers/Microsoft.Sql/servers/golive4/databases/sqldb',
+                'name': 'sqldb',
+                'type': 'Microsoft.Sql/servers/databases',
+                'location': 'West US',
+                'kind': 'v12.0,user',
+                'properties': {
+                    'databaseId': 'bf19fd8d-8b08-4b11-aceb-16dafee3c7cc',
+                    'edition': 'Basic',
+                    'status': 'Online',
+                    'serviceLevelObjective': 'Basic',
+                    'collation': 'SQL_Latin1_General_CP1_CI_AS',
+                    'maxSizeBytes': '2147483648',
+                    'creationDate': '2016-07-08T08:54:17.73Z',
+                    'currentServiceObjectiveId': 'dd6d99bb-f193-4ec1-86f2-43d3bccbc49c',
+                    'requestedServiceObjectiveId': 'dd6d99bb-f193-4ec1-86f2-43d3bccbc49c',
+                    'requestedServiceObjectiveName': null,
+                    'defaultSecondaryLocation': 'East US',
+                    'earliestRestoreDate': '2016-07-08T09:05:03.543Z',
+                    'elasticPoolName': null,
+                    'containmentState': 2
+                },
+                'sqlServerName': 'golive4',
+                'administratorLogin': 'greg',
+                'administratorLoginPassword': 'P@ssw0rd!'
+            },
+            azure: azure
+        };
+
+        cd = new cmdDeprovision(validParams);
+    });
+
+    describe('Deprovision should return 200 ...', function () {
+        it('returns 200 if no err', function (done) {
+            cd.deprovision(sqldbOps, function (err, result) {
+                should.not.exist(err);
+                result.state.should.equal('succeeded');
+                result.description.should.equal('Unregistered the database');
                 done();
             });
         });

--- a/test/unit/services/azuresqldb/poll-spec.js
+++ b/test/unit/services/azuresqldb/poll-spec.js
@@ -1,6 +1,6 @@
 /*
   good instanceId : e2778b98-0b6b-11e6-9db3-000d3a002ed5
-  test: 
+  test:
 */
 
 /* jshint camelcase: false */
@@ -469,3 +469,47 @@ describe('SqlDb - Poll - polling database after update operation', function () {
     });
 });
 
+describe('SqlDb - Poll - registering existing database plan', function () {
+
+    var cp;
+
+    describe('the last operation is provision', function () {
+        before(function () {
+            afterProvisionValidParams.plan_id = '4b1cfc28-dda6-407b-abeb-7aa0b89f52bf';
+            cp = new cmdPoll(afterProvisionValidParams);
+        });
+
+        after(function () {
+            afterProvisionValidParams.plan_id = '3819fdfa-0aaa-11e6-86f4-000d3a002ed5';
+        });
+
+        it('should directly succeed', function (done) {
+            cp.poll(sqldbOps, function (err, result) {
+                should.not.exist(err);
+                result.value.state.should.equal('succeeded');
+                result.value.description.should.equal('Registered the database as a service instance.');
+                done();
+            });
+        });
+    });
+
+    describe('the last operation is provision', function () {
+        before(function () {
+            afterDeprovisionValidParams.plan_id = '4b1cfc28-dda6-407b-abeb-7aa0b89f52bf';
+            cp = new cmdPoll(afterDeprovisionValidParams);
+        });
+
+        after(function () {
+            afterDeprovisionValidParams.plan_id = '3819fdfa-0aaa-11e6-86f4-000d3a002ed5';
+        });
+
+        it('should directly succeed', function (done) {
+            cp.poll(sqldbOps, function (err, result) {
+                should.not.exist(err);
+                result.value.state.should.equal('succeeded');
+                result.value.description.should.equal('Unregistered the database.');
+                done();
+            });
+        });
+    });
+});

--- a/test/unit/services/azuresqldb/unbind-spec.js
+++ b/test/unit/services/azuresqldb/unbind-spec.js
@@ -1,6 +1,6 @@
 /*
   good instanceId : e2778b98-0b6b-11e6-9db3-000d3a002ed5
-  test: 
+  test:
 */
 
 /* jshint camelcase: false */
@@ -88,6 +88,65 @@ describe('SqlDb - Unbind', function () {
 
     describe('', function () {
         sinon.stub(sqldbOps, 'executeSql').yields(null);
+        it('should not exist error', function (done) {
+            cb.unbind(sqldbOps, function (err, result) {
+                should.not.exist(err);
+                done();
+            });
+        });
+    });
+});
+
+describe('SqlDb - Unbind - user-provided database login', function () {
+
+    var cb;
+
+    before(function () {
+
+        var validParams = {
+            instance_id: 'e2778b98-0b6b-11e6-9db3-000d3a002ed5',
+            service_id: 'fb9bc99e-0aa9-11e6-8a8a-000d3a002ed5',
+            plan_id: '3819fdfa-0aaa-11e6-86f4-000d3a002ed5',
+            parameters: {
+                sqlServerName: 'golive4',
+                sqldbName: 'sqldb',
+                userProvidedDatabaseLogin: 'fake-login',
+                userProvidedDatabaseLoginPassword: 'fake-login-password',
+            },
+            binding_result: {'databaseLogin':'asd'},
+            provisioning_result: {
+                'id': '/subscriptions/743f6ed6-83a8-46f0-822d-ea93b953952d/resourceGroups/sqldbResourceGroup/providers/Microsoft.Sql/servers/golive4/databases/sqldb',
+                'name': 'sqldb',
+                'type': 'Microsoft.Sql/servers/databases',
+                'location': 'West US',
+                'kind': 'v12.0,user',
+                'properties': {
+                    'databaseId': 'bf19fd8d-8b08-4b11-aceb-16dafee3c7cc',
+                    'edition': 'Basic',
+                    'status': 'Online',
+                    'serviceLevelObjective': 'Basic',
+                    'collation': 'SQL_Latin1_General_CP1_CI_AS',
+                    'maxSizeBytes': '2147483648',
+                    'creationDate': '2016-07-08T08:54:17.73Z',
+                    'currentServiceObjectiveId': 'dd6d99bb-f193-4ec1-86f2-43d3bccbc49c',
+                    'requestedServiceObjectiveId': 'dd6d99bb-f193-4ec1-86f2-43d3bccbc49c',
+                    'requestedServiceObjectiveName': null,
+                    'defaultSecondaryLocation': 'East US',
+                    'earliestRestoreDate': '2016-07-08T09:05:03.543Z',
+                    'elasticPoolName': null,
+                    'containmentState': 2
+                },
+                'sqlServerName': 'golive4',
+                'administratorLogin': 'greg',
+                'administratorLoginPassword': 'P@ssw0rd!'
+            },
+            azure: azure
+        };
+
+        cb = new cmdUnbind(validParams);
+    });
+
+    describe('', function () {
         it('should not exist error', function (done) {
             cb.unbind(sqldbOps, function (err, result) {
                 should.not.exist(err);


### PR DESCRIPTION
Example provisioning parameters:
```
{
    "sqlServerName": "<name-of-server-provided-in-manifest>",
    "sqldbName": "<name-of-existing-database>",
    "userProvidedDatabaseLogin": "<name-of-existing-database-login>",
    "userProvidedDatabaseLoginPassword": "<password-of-existing-database-login>"
}
```