### PR TITLE
Use `rediss` schema in redisUrl in binding credentials

### DIFF
--- a/docs/azure-redis-cache.md
+++ b/docs/azure-redis-cache.md
@@ -93,11 +93,11 @@
   }
   ```
 
-  >**NOTE:**
+  **NOTE:**
 
-    * Please remove the comments in the JSON file before you use it.
+   * Please remove the comments in the JSON file before you use it.
 
-    * The `enableNonSslPort` setting has a effect on the `redisUrl` in the [credentials](#format-of-credentials) delivered by binding. If `true`, `redisUrl` would be in `redis` scheme with port `6379`. Else, `redisUrl` would be in `rediss` scheme with port `6380`. With `rediss`, please check if your client supports SSL connection. For Spring Cloud Connector users, you need to upgrade the Connector version to [2.0.3-RELEASE](https://github.com/spring-cloud/spring-cloud-connectors/releases/tag/v2.0.3.RELEASE) or higher.
+   * The `enableNonSslPort` setting has a effect on the `redisUrl` in the [credentials](#format-of-credentials) delivered by binding. If `true`, `redisUrl` would be in `redis` scheme with port `6379`. Else, `redisUrl` would be in `rediss` scheme with port `6380`. With `rediss`, please check if your client supports SSL connection. For Spring Cloud Connector users, you need to upgrade the Connector version to [2.0.3-RELEASE](https://github.com/spring-cloud/spring-cloud-connectors/releases/tag/v2.0.3.RELEASE) or higher.
 
   Above parameters are also the defaults if the broker operator doesn't change broker default settings. You can just run the following command to create a service instance without the json file:
 
@@ -163,9 +163,9 @@
   }
   ```
 
-  >**NOTE:**
+  **NOTE:**
 
-    * The `redisUrl` would be `rediss://*****:6380` if non-SSL port is not enabled.
+   * The `redisUrl` would be `rediss://*****:6380` if non-SSL port is not enabled.
 
 ## Unbinding
 

--- a/docs/azure-redis-cache.md
+++ b/docs/azure-redis-cache.md
@@ -97,7 +97,7 @@
 
     * Please remove the comments in the JSON file before you use it.
 
-    * Please set `enableNonSslPort: true` for redis instances bound to Spring apps.
+    * The `enableNonSslPort` setting has a effect on the `redisUrl` in the [credentials](#format-of-credentials) delivered by binding. If `true`, `redisUrl` would be in `redis` scheme with port `6379`. Else, `redisUrl` would be in `rediss` scheme with port `6380`. With `rediss`, please check if your client supports SSL connection. For Spring Cloud Connector users, you need to upgrade the Connector version to [2.0.3-RELEASE](https://github.com/spring-cloud/spring-cloud-connectors/releases/tag/v2.0.3.RELEASE) or higher.
 
   Above parameters are also the defaults if the broker operator doesn't change broker default settings. You can just run the following command to create a service instance without the json file:
 
@@ -162,6 +162,10 @@
      "redisUrl": "redis://<cache-name>:<primary-key>@<cache-name>.redis.cache.windows.net:6379"
   }
   ```
+
+  >**NOTE:**
+
+    * The `redisUrl` would be `rediss://*****:6380` if non-SSL port is not enabled.
 
 ## Unbinding
 

--- a/lib/services/azurerediscache/cmd-bind.js
+++ b/lib/services/azurerediscache/cmd-bind.js
@@ -1,13 +1,48 @@
 /* jshint camelcase: false */
 /* jshint newcap: false */
+var util = require('util');
+var urlencode = require('urlencode');
 
 var cacheBind = function(params) {
   var reqParams = params.parameters || {};
   var resourceGroup = reqParams.resourceGroup || '';
   var cacheName = reqParams.cacheName || '';
+  var provisioningResult = params.provisioning_result;
 
   this.bind = function(redis, callback) {
-    redis.bind(resourceGroup, cacheName, callback);
+    redis.bind(resourceGroup, cacheName, function(err, accessKeys) {
+      if (err) {
+        return callback(err);
+      }
+      var urlSchema, urlPort;
+      var enableNonSslPort = null;
+      if (reqParams.parameters) {
+        enableNonSslPort = reqParams.parameters.enableNonSslPort;
+      }
+      if (!enableNonSslPort) {
+        urlSchema = 'rediss';
+        urlPort = 6380;
+      } else {
+        urlSchema = 'redis';
+        urlPort = 6379;
+      }
+      var redisUrl = util.format('%s://%s:%s@%s:%s',
+        urlSchema,
+        provisioningResult.name,
+        urlencode(accessKeys.primaryKey),
+        provisioningResult.hostName,
+        urlPort);
+      var credentials = {
+        name: provisioningResult.name,
+        hostname: provisioningResult.hostName,
+        port: provisioningResult.port,
+        sslPort: provisioningResult.sslPort,
+        primaryKey: accessKeys.primaryKey,
+        secondaryKey: accessKeys.secondaryKey,
+        redisUrl: redisUrl
+      };
+      return callback(null, credentials);
+    });
   };
 };
 

--- a/lib/services/azurerediscache/index.js
+++ b/lib/services/azurerediscache/index.js
@@ -14,8 +14,6 @@ var cmdDeprovision = require('./cmd-deprovision');
 var cmdBind = require('./cmd-bind');
 var redisClient = require('./client');
 var Reply = require('../../common/reply');
-var util = require('util');
-var urlencode = require('urlencode');
 
 // Space Scoping if enabled needs unique names in multi-tenant environments
 Config = common.fixNamesIfSpaceScopingEnabled(Config);
@@ -119,38 +117,21 @@ Handlers.bind = function (params, next) {
 
   log.debug('Redis Cache/index/bind/params: %j', params);
 
-  var provisioningResult = params.provisioning_result;
-
   var cp = new cmdBind(params);
 
   redisClient.initialize(params.azure);
-  cp.bind(redisClient, function(err, accessKeys) {
+  cp.bind(redisClient, function(err, credentials) {
     if (err) {
       common.handleServiceError(err, next);
     } else {
-
-      var redisUrl = util.format('redis://%s:%s@%s:%s',
-                                  provisioningResult.name,
-                                  urlencode(accessKeys.primaryKey),
-                                  provisioningResult.hostName,
-                                  provisioningResult.port);
       // contents of reply.value winds up in VCAP_SERVICES
       var reply = {
         statusCode: HttpStatus.CREATED,
         code: HttpStatus.getStatusText(HttpStatus.CREATED),
         value: {
-          credentials: {
-            name: provisioningResult.name,
-            hostname: provisioningResult.hostName,
-            port: provisioningResult.port,
-            sslPort: provisioningResult.sslPort,
-            primaryKey: accessKeys.primaryKey,
-            secondaryKey: accessKeys.secondaryKey,
-            redisUrl: redisUrl
-          }
+          credentials: credentials
         }
       };
-
       next(null, reply, {});
     }
   });

--- a/test/integration/lifecycle.js
+++ b/test/integration/lifecycle.js
@@ -228,7 +228,7 @@ function runLifecycle(testMatrix) {
             'parameters':service.updatingParameters
           })
           .end(function (err, res) {
-            res.should.have.status(200);
+            res.status.should.be.oneOf([200, 202]);
             done(err);
           });
         });

--- a/test/integration/lifecycle.js
+++ b/test/integration/lifecycle.js
@@ -228,7 +228,7 @@ function runLifecycle(testMatrix) {
             'parameters':service.updatingParameters
           })
           .end(function (err, res) {
-            res.status.should.be.oneOf([200, 202]);
+            res.status.should.be.oneOf([200, 201, 202]);
             done(err);
           });
         });

--- a/test/unit/services/azurerediscache/bind-spec.js
+++ b/test/unit/services/azurerediscache/bind-spec.js
@@ -13,7 +13,7 @@ var cmdBind = require('../../../../lib/services/azurerediscache/cmd-bind');
 var redisClient = require('../../../../lib/services/azurerediscache/client');
 var azure = require('../helpers').azure;
 var msRestRequest = require('../../../../lib/common/msRestRequest');
-  
+
 var mockingHelper = require('../mockingHelper');
 mockingHelper.backup();
 redisClient.initialize(azure);
@@ -24,10 +24,16 @@ describe('RedisCache - Bind', function() {
 
     before(function() {
         validParams = {
-            instance_id : 'b259c5e0-7442-46bc-970c-9912613077dd',
-            parameters : {
+            instance_id: 'b259c5e0-7442-46bc-970c-9912613077dd',
+            parameters: {
                 resourceGroup: 'redisResourceGroup',
                 cacheName: 'C0CacheNC'
+            },
+            provisioning_result: {
+              name: 'C0CacheNC',
+              hostname: 'C0CacheNC.fakedomain.com',
+              port: 6379,
+              sslPort: 6380
             },
             azure: azure
         };
@@ -35,17 +41,18 @@ describe('RedisCache - Bind', function() {
         msRestRequest.POST.withArgs('https://management.azure.com//subscriptions/55555555-4444-3333-2222-111111111111/resourceGroups/redisResourceGroup/providers/Microsoft.Cache/Redis/C0CacheNC/listKeys')
           .yields(null, {statusCode: 200}, JSON.stringify(fakeAccessKeys));
     });
-    
+
     after(function() {
         mockingHelper.restore();
     });
-    
+
     describe('When access keys are retrievied from Azure successfully', function() {
         it('should return credentials', function(done) {
             var cp = new cmdBind(validParams);
-            cp.bind(redisClient, function(err, accessKeys) {
+            cp.bind(redisClient, function(err, credentials) {
                 should.not.exist(err);
-                accessKeys.should.eql(fakeAccessKeys);
+                credentials.primaryKey.should.eql(fakeAccessKeys.primaryKey);
+                credentials.secondaryKey.should.eql(fakeAccessKeys.secondaryKey);
                 done();
             });
         });

--- a/test/utils/azurerediscacheClient.js
+++ b/test/utils/azurerediscacheClient.js
@@ -6,7 +6,7 @@ var statusCode = require('./statusCode');
 module.exports = function() {
   var clientName = 'azurerediscacheClient';
   var log = common.getLogger(clientName);
-  
+
   this.validateCredential = function(credential, next) {
     log.debug('credential: %j', credential);
     try {
@@ -15,13 +15,13 @@ module.exports = function() {
         log.error('Client Error: ' + err);
         client.end(false);
       });
-      
-      var urlClient = redis.createClient(credential.redisUrl);
+
+      var urlClient = redis.createClient(credential.redisUrl, {'tls': {servername: credential.hostname}});
       urlClient.on('error', function (err) {
         log.error('Client created through url Error: ' + err);
         urlClient.end(false);
       });
-      
+
       var key = clientName + 'key' + Math.floor(Math.random()*1000);
       var value = clientName + 'value' + Math.floor(Math.random()*1000);
       async.waterfall([
@@ -74,8 +74,8 @@ module.exports = function() {
         } else {
           next(statusCode.PASS);
         }
-      }); 
-  
+      });
+
     } catch(ex) {
       log.error('Got an exception: ' + ex);
       next(statusCode.FAIL);


### PR DESCRIPTION
Solve #166 .
When the provisioning parameter `enableNonSslPort` is set to `false`, the value of `redisUrl` in binding credentials will start with `rediss`.
The schema `rediss` can be recognized by Spring Cloud Connector now in [2.0.3.RELEASE](https://github.com/spring-cloud/spring-cloud-connectors/releases/tag/v2.0.3.RELEASE). Some other clients such as [node-redis](https://github.com/NodeRedis/node_redis#rediscreateclient) can also recognize `rediss`.