### PR TITLE
Upgrade MySQL/PostgreSQL to use gen5 hardware

### DIFF
--- a/lib/common/index.js
+++ b/lib/common/index.js
@@ -225,8 +225,8 @@ module.exports.API_VERSION = {
     DOCDB: '2015-04-08',                 // https://docs.microsoft.com/en-us/rest/api/documentdbresourceprovider/databaseaccounts
     STORAGE_ACCOUNT: '2016-01-01',       // https://docs.microsoft.com/en-us/rest/api/storagerp/storageaccounts#StorageAccounts_CheckNameAvailability
     REDIS: '2016-04-01',                 // https://docs.microsoft.com/en-us/rest/api/redis/redis
-    MYSQL: '2017-04-30-preview',
-    POSTGRESQL: '2017-04-30-preview',
+    MYSQL: '2017-12-01',
+    POSTGRESQL: '2017-12-01',
     COSMOSDB: '2015-04-08'               // https://docs.microsoft.com/en-us/rest/api/documentdbresourceprovider/databaseaccounts
   },
   AzureChinaCloud: {

--- a/lib/services/azuremysqldb/cmd-provision.js
+++ b/lib/services/azuremysqldb/cmd-provision.js
@@ -14,10 +14,10 @@ var mysqldbProvision = function (params) {
 
     var reqParams = params.parameters || {};
     var mysqlServerName = reqParams.mysqlServerName || '';
-    
+
     var resourceGroupName = reqParams.resourceGroup || '';
     var location = reqParams.location || '';
-    
+
     var administratorLogin = null, administratorLoginPassword = null;
     if (reqParams.mysqlServerParameters) {
         var properties = reqParams.mysqlServerParameters.properties;
@@ -26,28 +26,29 @@ var mysqldbProvision = function (params) {
             administratorLoginPassword = properties.administratorLoginPassword;
         }
     }
-        
+
     log.info(util.format('cmd-provision: resourceGroupName: %s, mysqlServerName: %s', resourceGroupName, mysqlServerName));
-    
+
     var planId = params.plan_id;
     Config.plans.forEach(function (item) {
         if (planId === item.id) {
             reqParams.sku = {};
-            reqParams.sku.name = 'SkuName';
+            reqParams.sku.family = "Gen5";
+            reqParams.sku.name = util.format('B_Gen5_%s', item.metadata.details.capacity);
             reqParams.sku.tier = item.metadata.details.tier;
             reqParams.sku.capacity = item.metadata.details.capacity;
         }
     });
 
     this.provision = function (mysqldbOperations, next) {
-        
+
         var groupParameters = {
             location: location
         };
         reqParams.location = location;
-        
+
         mysqldbOperations.setParameters(resourceGroupName, mysqlServerName, location);
-        
+
         async.waterfall([
             function (callback) {  // get mysql server status (existence check)
                 mysqldbOperations.getServer(function (err, result) {
@@ -95,7 +96,7 @@ var mysqldbProvision = function (params) {
                         result.body.administratorLoginPassword = administratorLoginPassword;
                         result.body.serverPollingUrl = serverPollingUrl;
                         result.body.mysqlDatabaseName = reqParams.mysqlDatabaseName;
-                            
+
                         result.value = {};
                         result.value.state = 'in progress';
                         result.value.description = 'Creating server ' + reqParams.mysqlServerName + '.';
@@ -137,7 +138,7 @@ var mysqldbProvision = function (params) {
         }
         return true;    // no firewall rule at all, is ok.
     };
-    
+
     this.parametersNotProvided = function () {
         var ret = [];
 
@@ -154,11 +155,10 @@ var mysqldbProvision = function (params) {
     this.getInvalidParams = function () {
         var invalidParams = [];
         invalidParams = invalidParams.concat(this.parametersNotProvided());
-        
+
         if (!this.firewallRuleIsOk()) invalidParams.push('allowMysqlServerFirewallRules');
         return invalidParams;
     };
 };
 
 module.exports = mysqldbProvision;
-

--- a/lib/services/azuremysqldb/cmd-provision.js
+++ b/lib/services/azuremysqldb/cmd-provision.js
@@ -33,7 +33,7 @@ var mysqldbProvision = function (params) {
     Config.plans.forEach(function (item) {
         if (planId === item.id) {
             reqParams.sku = {};
-            reqParams.sku.family = "Gen5";
+            reqParams.sku.family = 'Gen5';
             reqParams.sku.name = util.format('B_Gen5_%s', item.metadata.details.capacity);
             reqParams.sku.tier = item.metadata.details.tier;
             reqParams.sku.capacity = item.metadata.details.capacity;

--- a/lib/services/azuremysqldb/service.json
+++ b/lib/services/azuremysqldb/service.json
@@ -19,7 +19,7 @@
       "id": "a05c9967-9f20-4b17-8c66-bb32ab396fcd",
       "name": "basic50",
       "free": false,
-      "description": "Basic Tier, 50 DTUs. See preview pricing here: https://azure.microsoft.com/en-us/pricing/details/mysql. We'll update it after GA.",
+      "description": "Basic Tier, 50 DTUs.",
       "metadata": {
         "displayName": "Basic50",
         "details": {
@@ -38,58 +38,6 @@
         "details": {
           "tier": "Basic",
           "capacity": 100
-        }
-      }
-    },
-    {
-      "id": "1694df50-10e8-4f97-9bb3-513ce49395db",
-      "name": "standard100",
-      "free": false,
-      "description": "Standard Tier, 100 DTUs",
-      "metadata": {
-        "displayName": "Standard100",
-        "details": {
-          "tier": "Standard",
-          "capacity": 100
-        }
-      }
-    },
-    {
-      "id": "5b95f2d0-8ab4-4e8c-b147-134dc803c717",
-      "name": "standard200",
-      "free": false,
-      "description": "Standard Tier, 200 DTUs",
-      "metadata": {
-        "displayName": "Standard200",
-        "details": {
-          "tier": "Standard",
-          "capacity": 200
-        }
-      }
-    },
-    {
-      "id": "bbf776dc-6701-4d54-85cb-d1ce2a997c12",
-      "name": "standard400",
-      "free": false,
-      "description": "Standard Tier, 400 DTUs",
-      "metadata": {
-        "displayName": "Standard400",
-        "details": {
-          "tier": "Standard",
-          "capacity": 400
-        }
-      }
-    },
-    {
-      "id": "0df075da-8ca1-4480-8508-e4c8d577c932",
-      "name": "standard800",
-      "free": false,
-      "description": "Standard Tier, 800 DTUs",
-      "metadata": {
-        "displayName": "Standard800",
-        "details": {
-          "tier": "Standard",
-          "capacity": 800
         }
       }
     }

--- a/lib/services/azuremysqldb/service.json
+++ b/lib/services/azuremysqldb/service.json
@@ -16,28 +16,28 @@
   },
   "plans": [
     {
-      "id": "a05c9967-9f20-4b17-8c66-bb32ab396fcd",
-      "name": "basic50",
+      "id": "a1603ad1-2eba-402f-8877-7e5a9a2d8075",
+      "name": "basic1",
       "free": false,
-      "description": "Basic Tier, 50 DTUs.",
+      "description": "Basic Tier, 1 vCore.",
       "metadata": {
-        "displayName": "Basic50",
+        "displayName": "Basic1",
         "details": {
           "tier": "Basic",
-          "capacity": 50
+          "capacity": 1
         }
       }
     },
     {
-      "id": "d8d5cac9-d975-48ea-9ac4-8232f92bcb93",
-      "name": "basic100",
+      "id": "ed20f333-c3a0-40c5-99d9-18986b04d673",
+      "name": "basic2",
       "free": false,
-      "description": "Basic Tier, 100 DTUs",
+      "description": "Basic Tier, 2 vCores",
       "metadata": {
-        "displayName": "Basic100",
+        "displayName": "Basic2",
         "details": {
           "tier": "Basic",
-          "capacity": 100
+          "capacity": 2
         }
       }
     }

--- a/lib/services/azurepostgresqldb/cmd-provision.js
+++ b/lib/services/azurepostgresqldb/cmd-provision.js
@@ -14,10 +14,10 @@ var postgresqldbProvision = function (params) {
 
     var reqParams = params.parameters || {};
     var postgresqlServerName = reqParams.postgresqlServerName || '';
-    
+
     var resourceGroupName = reqParams.resourceGroup || '';
     var location = reqParams.location || '';
-    
+
     var administratorLogin = null, administratorLoginPassword = null;
     if (reqParams.postgresqlServerParameters) {
         var properties = reqParams.postgresqlServerParameters.properties;
@@ -26,28 +26,29 @@ var postgresqldbProvision = function (params) {
             administratorLoginPassword = properties.administratorLoginPassword;
         }
     }
-        
+
     log.info(util.format('cmd-provision: resourceGroupName: %s, postgresqlServerName: %s', resourceGroupName, postgresqlServerName));
-    
+
     var planId = params.plan_id;
     Config.plans.forEach(function (item) {
         if (planId === item.id) {
             reqParams.sku = {};
-            reqParams.sku.name = 'SkuName';
+            reqParams.sku.family = "Gen5";
+            reqParams.sku.name = util.format('B_Gen5_%s', item.metadata.details.capacity);
             reqParams.sku.tier = item.metadata.details.tier;
             reqParams.sku.capacity = item.metadata.details.capacity;
         }
     });
 
     this.provision = function (postgresqldbOperations, next) {
-        
+
         var groupParameters = {
             location: location
         };
         reqParams.location = location;
-        
+
         postgresqldbOperations.setParameters(resourceGroupName, postgresqlServerName, location);
-        
+
         async.waterfall([
             function (callback) {  // get postgresql server status (existence check)
                 postgresqldbOperations.getServer(function (err, result) {
@@ -94,7 +95,7 @@ var postgresqldbProvision = function (params) {
                         result.body.administratorLoginPassword = administratorLoginPassword;
                         result.body.serverPollingUrl = serverPollingUrl;
                         result.body.postgresqlDatabaseName = reqParams.postgresqlDatabaseName;
-                            
+
                         result.value = {};
                         result.value.state = 'in progress';
                         result.value.description = 'Creating server ' + reqParams.postgresqlServerName + '.';
@@ -136,7 +137,7 @@ var postgresqldbProvision = function (params) {
         }
         return true;    // no firewall rule at all, is ok.
     };
-    
+
     this.parametersNotProvided = function () {
         var ret = [];
 
@@ -153,11 +154,10 @@ var postgresqldbProvision = function (params) {
     this.getInvalidParams = function () {
         var invalidParams = [];
         invalidParams = invalidParams.concat(this.parametersNotProvided());
-        
+
         if (!this.firewallRuleIsOk()) invalidParams.push('allowPostgresqlServerFirewallRules');
         return invalidParams;
     };
 };
 
 module.exports = postgresqldbProvision;
-

--- a/lib/services/azurepostgresqldb/cmd-provision.js
+++ b/lib/services/azurepostgresqldb/cmd-provision.js
@@ -33,7 +33,7 @@ var postgresqldbProvision = function (params) {
     Config.plans.forEach(function (item) {
         if (planId === item.id) {
             reqParams.sku = {};
-            reqParams.sku.family = "Gen5";
+            reqParams.sku.family = 'Gen5';
             reqParams.sku.name = util.format('B_Gen5_%s', item.metadata.details.capacity);
             reqParams.sku.tier = item.metadata.details.tier;
             reqParams.sku.capacity = item.metadata.details.capacity;

--- a/lib/services/azurepostgresqldb/service.json
+++ b/lib/services/azurepostgresqldb/service.json
@@ -19,7 +19,7 @@
       "id": "bb6ddfd0-4d8f-4496-aa33-d64ad9562c1f",
       "name": "basic50",
       "free": false,
-      "description": "Basic Tier, 50 DTUs. See preview pricing here: https://azure.microsoft.com/en-us/pricing/details/mysql. We'll update it after GA.",
+      "description": "Basic Tier, 50 DTUs.",
       "metadata": {
         "displayName": "Basic50",
         "details": {
@@ -38,58 +38,6 @@
         "details": {
           "tier": "Basic",
           "capacity": 100
-        }
-      }
-    },
-    {
-      "id": "1464a2cd-ad32-4f6b-ba80-9d052e4a0fe3",
-      "name": "standard100",
-      "free": false,
-      "description": "Standard Tier, 100 DTUs",
-      "metadata": {
-        "displayName": "Standard100",
-        "details": {
-          "tier": "Standard",
-          "capacity": 100
-        }
-      }
-    },
-    {
-      "id": "83c03465-9b1d-408d-ad13-78bc4b205295",
-      "name": "standard200",
-      "free": false,
-      "description": "Standard Tier, 200 DTUs",
-      "metadata": {
-        "displayName": "Standard200",
-        "details": {
-          "tier": "Standard",
-          "capacity": 200
-        }
-      }
-    },
-    {
-      "id": "ef31f27f-c71b-4193-a0f5-61dd1a8be129",
-      "name": "standard400",
-      "free": false,
-      "description": "Standard Tier, 400 DTUs",
-      "metadata": {
-        "displayName": "Standard400",
-        "details": {
-          "tier": "Standard",
-          "capacity": 400
-        }
-      }
-    },
-    {
-      "id": "316b0d63-856e-4d34-b5b1-d7c6f83f74f9",
-      "name": "standard800",
-      "free": false,
-      "description": "Standard Tier, 800 DTUs",
-      "metadata": {
-        "displayName": "Standard800",
-        "details": {
-          "tier": "Standard",
-          "capacity": 800
         }
       }
     }

--- a/lib/services/azurepostgresqldb/service.json
+++ b/lib/services/azurepostgresqldb/service.json
@@ -16,28 +16,28 @@
   },
   "plans": [
     {
-      "id": "bb6ddfd0-4d8f-4496-aa33-d64ad9562c1f",
-      "name": "basic50",
+      "id": "ffc2a56b-637d-43bb-8e0c-f12750980ad1",
+      "name": "basic1",
       "free": false,
-      "description": "Basic Tier, 50 DTUs.",
+      "description": "Basic Tier, 1 vCore.",
       "metadata": {
-        "displayName": "Basic50",
+        "displayName": "Basic1",
         "details": {
           "tier": "Basic",
-          "capacity": 50
+          "capacity": 1
         }
       }
     },
     {
-      "id": "ffc1e3c8-0e24-471d-8683-1b42e100bb14",
+      "id": "3da8d4d0-9ca3-4ea7-9195-382d4351cf66",
       "name": "basic100",
       "free": false,
-      "description": "Basic Tier, 100 DTUs",
+      "description": "Basic Tier, 2 vCores",
       "metadata": {
-        "displayName": "Basic100",
+        "displayName": "Basic2",
         "details": {
           "tier": "Basic",
-          "capacity": 100
+          "capacity": 2
         }
       }
     }

--- a/lib/services/azurepostgresqldb/service.json
+++ b/lib/services/azurepostgresqldb/service.json
@@ -30,7 +30,7 @@
     },
     {
       "id": "3da8d4d0-9ca3-4ea7-9195-382d4351cf66",
-      "name": "basic100",
+      "name": "basic2",
       "free": false,
       "description": "Basic Tier, 2 vCores",
       "metadata": {


### PR DESCRIPTION
Standard plans are removed as they are no longer supported. For new tiers -- General Purpose and Memory Optimized, we don't add them as MASB is in maintenance mode.