### PR TITLE
Unbinding returns 410 instead of 500 for bindings which are not existed

### DIFF
--- a/lib/broker/db/sqlserver/index.js
+++ b/lib/broker/db/sqlserver/index.js
@@ -76,7 +76,7 @@ Database.prototype.createServiceInstance = function(params, callback) {
       'values (@azureInstanceId, @status, @instanceId, @serviceId, @planId, @organizationGuid, @spaceGuid, @parameters, @lastOperation)',
     db.instanceTableName
   );
-    
+
   var sqlParameters = {
     'azureInstanceId': azureInstanceId,
     'status': 'pending',
@@ -264,10 +264,10 @@ Database.prototype.setServiceInstance = function (serviceInstance, callback) {
   provisioningResult = encryptionHelper.encryptText(db.encryptionKey, instanceId, provisioningResult);
 
   var sql = util.format(
-    'UPDATE %s SET' + 
+    'UPDATE %s SET' +
       ' status=@status,' +
-      ' planId=@planId,' + 
-      ' parameters=@parameters,' + 
+      ' planId=@planId,' +
+      ' parameters=@parameters,' +
       ' lastOperation=@lastOperation,' +
       ' provisioningResult=@provisioningResult,' +
       ' state=@state,' +
@@ -381,7 +381,7 @@ Database.prototype.getServiceBinding = function(bindingId, callback) {
 
     if (result.length === 0) {
       return common.handleServiceErrorEx(
-        HttpStatus.INTERNAL_SERVER_ERROR,
+        HttpStatus.GONE,
         util.format('The information of the service binding (bindingId=%s) is deleted.', bindingId),
         callback);
     }


### PR DESCRIPTION
According to [service broker API spec](https://github.com/openservicebrokerapi/servicebroker/blob/v2.14/spec.md#response-8), the broker should return 410 (Gone) for bindings which are not existed. MASB currently returns 500.

The behavior is required for such a case: Unbinding timeout, CC supposes unbinding failed. But actually unbinding succeeded in MASB side. Then unbinding retries will fail forever.

Did an e2e test to validate the PR:
  1. Create a service and bind
  2. Manually delete the binding record in broker database
  3. Unbind successfully
  4. Did find 410 (Gone) with "cf logs meta-azure-service-broker --recent"
