### PR TITLE
Remove bad test case

### DIFF
--- a/test/integration/submatrix/sqldb.js
+++ b/test/integration/submatrix/sqldb.js
@@ -72,14 +72,7 @@ azuresqldb = {
     'password': '<string>',
     'uri': '<string>'
   },
-  e2e: false,
-  updatingParameters: {
-      'sqlServerParameters': {
-        'properties': {
-          'administratorLoginPassword': 'newPassword425'
-        }
-      }
-  }
+  e2e: false
 };
 testMatrix.push(azuresqldb);
 


### PR DESCRIPTION
This is a bad case as the lifecycle test tries updating before unbinding. It leads to a failed unbinding.