### PR TITLE
Resolve potential security vulnerability in the dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "engines": {
     "node": ">= 6.10.0"
   },
-  "version": "1.9.0",
+  "version": "1.10.0",
   "description": "A service broker to manage multiple Azure services in Cloud Foundry",
   "tags": [
     "service broker",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "typescript": "^2.3.2",
     "underscore": "1.8.3",
     "uuid": "3.2.1",
-    "deep-extend": "0.5.0",
+    "deep-extend": "0.5.1",
     "urlencode": "1.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
GitHub popped the alert: https://nvd.nist.gov/vuln/detail/CVE-2018-3750.

BTW update service broker version number -- it is ready to cut a release.