### PR TITLE
Add MASB tag for failover groups

### DIFF
--- a/lib/services/azuresqldbfailovergroup/client.js
+++ b/lib/services/azuresqldbfailovergroup/client.js
@@ -228,7 +228,8 @@ sqldbfgOperations.prototype.createFailoverGroup = function (readWriteEndpoint, c
       'databases': [
         that.primaryDbUrl.replace(that.resourceManagerEndpointUrl, '')
       ]
-    }
+    },
+    'tags': common.mergeTags({})
   };
 
   var headers = common.mergeCommonHeaders('client - createFailoverGroup', that.standardHeaders);


### PR DESCRIPTION
We didn't expose `tags` field to provisioning parameters. So it just merge an empty `{}` with MASB tag, for tracking purpose.